### PR TITLE
Removes the IEntity generic constraint from the UpdateViewModel fluent method. Removes parallel for each

### DIFF
--- a/Firebend.AutoCrud.ChangeTracking.EntityFramework/Firebend.AutoCrud.ChangeTracking.EntityFramework.csproj
+++ b/Firebend.AutoCrud.ChangeTracking.EntityFramework/Firebend.AutoCrud.ChangeTracking.EntityFramework.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Firebend.AutoCrud.ChangeTracking.Mongo/Firebend.AutoCrud.ChangeTracking.Mongo.csproj
+++ b/Firebend.AutoCrud.ChangeTracking.Mongo/Firebend.AutoCrud.ChangeTracking.Mongo.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Firebend.AutoCrud.ChangeTracking.Web/Firebend.AutoCrud.ChangeTracking.Web.csproj
+++ b/Firebend.AutoCrud.ChangeTracking.Web/Firebend.AutoCrud.ChangeTracking.Web.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Firebend.AutoCrud.ChangeTracking/Firebend.AutoCrud.ChangeTracking.csproj
+++ b/Firebend.AutoCrud.ChangeTracking/Firebend.AutoCrud.ChangeTracking.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Firebend.AutoCrud.Core/Firebend.AutoCrud.Core.csproj
+++ b/Firebend.AutoCrud.Core/Firebend.AutoCrud.Core.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Firebend.AutoCrud.DomainEvents.MassTransit/Firebend.AutoCrud.DomainEvents.MassTransit.csproj
+++ b/Firebend.AutoCrud.DomainEvents.MassTransit/Firebend.AutoCrud.DomainEvents.MassTransit.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Firebend.AutoCrud.EntityFramework.Elastic/Firebend.AutoCrud.EntityFramework.Elastic.csproj
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/Firebend.AutoCrud.EntityFramework.Elastic.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Firebend.AutoCrud.EntityFramework/Firebend.AutoCrud.EntityFramework.csproj
+++ b/Firebend.AutoCrud.EntityFramework/Firebend.AutoCrud.EntityFramework.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Firebend.AutoCrud.Generator/Firebend.AutoCrud.Generator.csproj
+++ b/Firebend.AutoCrud.Generator/Firebend.AutoCrud.Generator.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Firebend.AutoCrud.Generator/Implementations/EntityCrudGenerator.cs
+++ b/Firebend.AutoCrud.Generator/Implementations/EntityCrudGenerator.cs
@@ -36,7 +36,7 @@ namespace Firebend.AutoCrud.Generator.Implementations
             var stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            foreach(var builder in Builders)
+            foreach (var builder in Builders)
             {
                 var builderStopwatch = new Stopwatch();
                 builderStopwatch.Start();

--- a/Firebend.AutoCrud.Generator/Implementations/EntityCrudGenerator.cs
+++ b/Firebend.AutoCrud.Generator/Implementations/EntityCrudGenerator.cs
@@ -36,16 +36,17 @@ namespace Firebend.AutoCrud.Generator.Implementations
             var stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            Parallel.ForEach(Builders, builder =>
+            foreach(var builder in Builders)
             {
                 var builderStopwatch = new Stopwatch();
                 builderStopwatch.Start();
                 Generate(ServiceCollection, builder);
                 builderStopwatch.Stop();
                 Console.WriteLine($"Generated entity crud for {builder.SignatureBase} in {builderStopwatch.ElapsedMilliseconds} (ms)");
-            });
+            }
 
             stopwatch.Stop();
+
             Console.WriteLine($"All entities generated in {stopwatch.ElapsedMilliseconds} (ms)");
 
             return ServiceCollection;

--- a/Firebend.AutoCrud.Io.Web/Firebend.AutoCrud.Io.Web.csproj
+++ b/Firebend.AutoCrud.Io.Web/Firebend.AutoCrud.Io.Web.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Firebend.AutoCrud.Io/Firebend.AutoCrud.Io.csproj
+++ b/Firebend.AutoCrud.Io/Firebend.AutoCrud.Io.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Firebend.AutoCrud.Mongo/Firebend.AutoCrud.Mongo.csproj
+++ b/Firebend.AutoCrud.Mongo/Firebend.AutoCrud.Mongo.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Firebend.AutoCrud.Web/ControllerConfigurator.cs
+++ b/Firebend.AutoCrud.Web/ControllerConfigurator.cs
@@ -736,7 +736,7 @@ namespace Firebend.AutoCrud.Web
 
         public ControllerConfigurator<TBuilder, TKey, TEntity> WithUpdateViewModel<TViewModel>(
             Func<TViewModel, TEntity> from)
-            where TViewModel : class, IEntity<TKey>
+            where TViewModel : class
         {
             ViewModelGuard("Please register a update view model before adding controllers");
 
@@ -764,7 +764,7 @@ namespace Firebend.AutoCrud.Web
         }
 
         public ControllerConfigurator<TBuilder, TKey, TEntity> WithViewModel<TViewModel, TViewModelMapper>()
-            where TViewModel : class, IEntity<TKey>
+            where TViewModel : class
             where TViewModelMapper : IUpdateViewModelMapper<TKey, TEntity, TViewModel>,
                 ICreateViewModelMapper<TKey, TEntity, TViewModel>,
                 IReadViewModelMapper<TKey, TEntity, TViewModel>

--- a/Firebend.AutoCrud.Web/Firebend.AutoCrud.Web.csproj
+++ b/Firebend.AutoCrud.Web/Firebend.AutoCrud.Web.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.18</Version>
+        <Version>0.0.19</Version>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
IEntity is no longer a requirement for Update view models. i missed this one in my last PR 

i'm also taking out the parallel for each because i think its causing race conditions with the entity generator 