### PR TITLE
Forks/jacob/fix up swagger

### DIFF
--- a/Firebend.AutoCrud.ChangeTracking.EntityFramework/Firebend.AutoCrud.ChangeTracking.EntityFramework.csproj
+++ b/Firebend.AutoCrud.ChangeTracking.EntityFramework/Firebend.AutoCrud.ChangeTracking.EntityFramework.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.ChangeTracking.EntityFramework/Firebend.AutoCrud.ChangeTracking.EntityFramework.csproj
+++ b/Firebend.AutoCrud.ChangeTracking.EntityFramework/Firebend.AutoCrud.ChangeTracking.EntityFramework.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.ChangeTracking.EntityFramework/Firebend.AutoCrud.ChangeTracking.EntityFramework.csproj
+++ b/Firebend.AutoCrud.ChangeTracking.EntityFramework/Firebend.AutoCrud.ChangeTracking.EntityFramework.csproj
@@ -23,7 +23,6 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
     </ItemGroup>
 
 </Project>

--- a/Firebend.AutoCrud.ChangeTracking.EntityFramework/Interfaces/IChangeTrackingDbContextProvider.cs
+++ b/Firebend.AutoCrud.ChangeTracking.EntityFramework/Interfaces/IChangeTrackingDbContextProvider.cs
@@ -8,7 +8,7 @@ namespace Firebend.AutoCrud.ChangeTracking.EntityFramework.Interfaces
     /// <summary>
     /// Encapsulates logic for getting an Entity Framework context that will persist changes.
     /// </summary>
-    /// <typeparam name="TKey">
+    /// <typeparam name="TEntityKey">
     /// The type of key the entity uses.
     /// </typeparam>
     /// <typeparam name="TEntity">

--- a/Firebend.AutoCrud.ChangeTracking.Mongo/Firebend.AutoCrud.ChangeTracking.Mongo.csproj
+++ b/Firebend.AutoCrud.ChangeTracking.Mongo/Firebend.AutoCrud.ChangeTracking.Mongo.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.ChangeTracking.Mongo/Firebend.AutoCrud.ChangeTracking.Mongo.csproj
+++ b/Firebend.AutoCrud.ChangeTracking.Mongo/Firebend.AutoCrud.ChangeTracking.Mongo.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.ChangeTracking.Web/Abstractions/AbstractChangeTrackingReadController.cs
+++ b/Firebend.AutoCrud.ChangeTracking.Web/Abstractions/AbstractChangeTrackingReadController.cs
@@ -37,7 +37,7 @@ namespace Firebend.AutoCrud.ChangeTracking.Web.Abstractions
         [SwaggerOperation("Gets change tracking history for a specific {entityName}")]
         [SwaggerResponse(200, "Change tracking history for the given entity key")]
         [Produces("application/json")]
-        public virtual async Task<IActionResult> GetByEntityId(
+        public virtual async Task<ActionResult<EntityPagedResponse<ChangeTrackingViewModel<TKey, TEntity, TViewModel>>>> GetByEntityId(
             [Required][FromRoute] string entityId,
             [Required][FromQuery] EntitySearchRequest changeSearchRequest,
             CancellationToken cancellationToken)

--- a/Firebend.AutoCrud.ChangeTracking.Web/Firebend.AutoCrud.ChangeTracking.Web.csproj
+++ b/Firebend.AutoCrud.ChangeTracking.Web/Firebend.AutoCrud.ChangeTracking.Web.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.ChangeTracking.Web/Firebend.AutoCrud.ChangeTracking.Web.csproj
+++ b/Firebend.AutoCrud.ChangeTracking.Web/Firebend.AutoCrud.ChangeTracking.Web.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.ChangeTracking/Firebend.AutoCrud.ChangeTracking.csproj
+++ b/Firebend.AutoCrud.ChangeTracking/Firebend.AutoCrud.ChangeTracking.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.ChangeTracking/Firebend.AutoCrud.ChangeTracking.csproj
+++ b/Firebend.AutoCrud.ChangeTracking/Firebend.AutoCrud.ChangeTracking.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.ChangeTracking/Interfaces/IChangeTrackingService.cs
+++ b/Firebend.AutoCrud.ChangeTracking/Interfaces/IChangeTrackingService.cs
@@ -49,6 +49,7 @@ namespace Firebend.AutoCrud.ChangeTracking.Interfaces
         /// <summary>
         /// Tracks changes when an entity is updated.
         /// </summary>
+        /// <param name="domainEvent">
         /// The <see cref="EntityUpdatedDomainEvent{T}"/> containing information about an Entity Updated event.
         /// </param>
         /// <param name="cancellationToken">

--- a/Firebend.AutoCrud.Core/Firebend.AutoCrud.Core.csproj
+++ b/Firebend.AutoCrud.Core/Firebend.AutoCrud.Core.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Core/Firebend.AutoCrud.Core.csproj
+++ b/Firebend.AutoCrud.Core/Firebend.AutoCrud.Core.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.DomainEvents.MassTransit/Firebend.AutoCrud.DomainEvents.MassTransit.csproj
+++ b/Firebend.AutoCrud.DomainEvents.MassTransit/Firebend.AutoCrud.DomainEvents.MassTransit.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.DomainEvents.MassTransit/Firebend.AutoCrud.DomainEvents.MassTransit.csproj
+++ b/Firebend.AutoCrud.DomainEvents.MassTransit/Firebend.AutoCrud.DomainEvents.MassTransit.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.EntityFramework.Elastic/Firebend.AutoCrud.EntityFramework.Elastic.csproj
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/Firebend.AutoCrud.EntityFramework.Elastic.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.EntityFramework.Elastic/Firebend.AutoCrud.EntityFramework.Elastic.csproj
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/Firebend.AutoCrud.EntityFramework.Elastic.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.EntityFramework/Abstractions/Client/DbContextOptionsProvider.cs
+++ b/Firebend.AutoCrud.EntityFramework/Abstractions/Client/DbContextOptionsProvider.cs
@@ -1,0 +1,18 @@
+using System;
+using Firebend.AutoCrud.EntityFramework.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Firebend.AutoCrud.EntityFramework.Abstractions.Client
+{
+    public class DbContextOptionsProvider<TKey, TEntity> : IDbContextOptionsProvider<TKey, TEntity>
+    {
+        private readonly Func<string, DbContextOptions> _optionsFunc;
+
+        public DbContextOptionsProvider(Func<string, DbContextOptions> optionsFunc)
+        {
+            _optionsFunc = optionsFunc;
+        }
+
+        public DbContextOptions GetDbContextOptions(string connectionString) => _optionsFunc(connectionString);
+    }
+}

--- a/Firebend.AutoCrud.EntityFramework/EntityFrameworkEntityBuilder.cs
+++ b/Firebend.AutoCrud.EntityFramework/EntityFrameworkEntityBuilder.cs
@@ -9,6 +9,7 @@ using Firebend.AutoCrud.EntityFramework.ExceptionHandling;
 using Firebend.AutoCrud.EntityFramework.Including;
 using Firebend.AutoCrud.EntityFramework.Indexing;
 using Firebend.AutoCrud.EntityFramework.Interfaces;
+using Microsoft.EntityFrameworkCore;
 
 namespace Firebend.AutoCrud.EntityFramework
 {
@@ -76,7 +77,7 @@ namespace Firebend.AutoCrud.EntityFramework
         /// <param name="dbContextType">The type of the DbContext to use</param>
         /// <example>
         /// <code>
-        /// ef.AddEntity<Guid, WeatherForecast>(forecast => 
+        /// ef.AddEntity<Guid, WeatherForecast>(forecast =>
         ///    forecast.WithDbContext(typeof(AppDbContext))
         ///        .AddCrud()
         ///        .AddControllers()
@@ -99,7 +100,7 @@ namespace Firebend.AutoCrud.EntityFramework
         /// <typeparam name="TContext">The type of the DbContext to use</typeparam>
         /// <example>
         /// <code>
-        /// ef.AddEntity<Guid, WeatherForecast>(forecast => 
+        /// ef.AddEntity<Guid, WeatherForecast>(forecast =>
         ///    forecast.WithDbContext<AppDbContext>()
         ///        .AddCrud()
         ///        .AddControllers()
@@ -115,7 +116,7 @@ namespace Firebend.AutoCrud.EntityFramework
         /// <param name="type">The type of the search filter to use</param>
         /// <example>
         /// <code>
-        /// ef.AddEntity<Guid, WeatherForecast>(forecast => 
+        /// ef.AddEntity<Guid, WeatherForecast>(forecast =>
         ///    forecast.WithDbContext<AppDbContext>()
         ///        .WithSearchFilter(typeof(SearchFilter))
         ///        .AddCrud()
@@ -134,7 +135,7 @@ namespace Firebend.AutoCrud.EntityFramework
         /// <typeparam name="T">The type of the search filter to use</typeparam>
         /// <example>
         /// <code>
-        /// ef.AddEntity<Guid, WeatherForecast>(forecast => 
+        /// ef.AddEntity<Guid, WeatherForecast>(forecast =>
         ///    forecast.WithDbContext<AppDbContext>()
         ///        .WithSearchFilter<SearchFilter>()
         ///        .AddCrud()
@@ -149,7 +150,7 @@ namespace Firebend.AutoCrud.EntityFramework
         /// <param name="filter">A callback function returning whether to include the object in results for the search</param>
         /// <example>
         /// <code>
-        /// ef.AddEntity<Guid, WeatherForecast>(forecast => 
+        /// ef.AddEntity<Guid, WeatherForecast>(forecast =>
         ///    forecast.WithDbContext<AppDbContext>()
         ///        .WithSearchFilter((e, s) => e.TemperatureC > s)
         ///        .AddCrud()
@@ -170,7 +171,7 @@ namespace Firebend.AutoCrud.EntityFramework
         /// <param name="type">The function includes provider to use</param>
         /// <example>
         /// <code>
-        /// ef.AddEntity<Guid, WeatherForecast>(forecast => 
+        /// ef.AddEntity<Guid, WeatherForecast>(forecast =>
         ///    forecast.WithDbContext<AppDbContext>()
         ///        .WithIncludes(typeof(EntityIncludes))
         ///        .AddCrud()
@@ -190,7 +191,7 @@ namespace Firebend.AutoCrud.EntityFramework
         /// <typeparam name="TProvider">The function includes provider to use</typeparam>
         /// <example>
         /// <code>
-        /// ef.AddEntity<Guid, WeatherForecast>(forecast => 
+        /// ef.AddEntity<Guid, WeatherForecast>(forecast =>
         ///    forecast.WithDbContext<AppDbContext>()
         ///        .WithIncludes<FunctionIncludes>()
         ///        .AddCrud()
@@ -211,7 +212,7 @@ namespace Firebend.AutoCrud.EntityFramework
         /// <typeparam name="func">A callback function specifying the related model Includes to use for the model</typeparam>
         /// <example>
         /// <code>
-        /// ef.AddEntity<Guid, WeatherForecast>(forecast => 
+        /// ef.AddEntity<Guid, WeatherForecast>(forecast =>
         ///    forecast.WithDbContext<AppDbContext>()
         ///        .WithIncludes(forecasts => forecasts.Include(f => f.LastUpdatedBy))
         ///        .AddCrud()
@@ -223,6 +224,67 @@ namespace Firebend.AutoCrud.EntityFramework
             WithRegistrationInstance<IEntityFrameworkIncludesProvider<TKey, TEntity>>(
                 new FunctionIncludesProvider<TKey, TEntity>(func));
 
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies EntityFramework Db Context options. Used when creating a change tracking context or a sharded context.
+        /// </summary>
+        /// <param name="type">
+        /// The <see cref="Type"/> that specifies a class that implements <see cref="IDbContextOptionsProvider{TKey,TEntity}"/>
+        /// </param>
+        /// <example>
+        /// <code>
+        /// ef.AddEntity<Guid, WeatherForecast>(forecast =>
+        ///    forecast.WithDbContext<AppDbContext>()
+        ///        .WithDbOptionsProvider(typeof(AppDbContextOptionsProvider))
+        ///        .AddCrud()
+        ///        .AddControllers()
+        /// </code>
+        /// </example>
+        public EntityFrameworkEntityBuilder<TKey, TEntity> WithDbOptionsProvider(Type type)
+        {
+            WithRegistration<IDbContextOptionsProvider<TKey, TEntity>>(type);
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies EntityFramework Db Context options. Used when creating a change tracking context or a sharded context.
+        /// </summary>
+        /// <typeparam name="TProvider">The type that implements <see cref="IDbContextOptionsProvider{TKey,TEntity}"/></typeparam>
+        /// <example>
+        /// <code>
+        /// ef.AddEntity<Guid, WeatherForecast>(forecast =>
+        ///    forecast.WithDbContext<AppDbContext>()
+        ///        .WithDbOptionsProvider<AppDbContextOptionsProvider>()
+        ///        .AddCrud()
+        ///        .AddControllers()
+        /// </code>
+        /// </example>
+        public EntityFrameworkEntityBuilder<TKey, TEntity> WithDbOptionsProvider<TProvider>()
+        {
+            WithRegistration<IDbContextOptionsProvider<TKey, TEntity>, TProvider>();
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies EntityFramework Db Context options. Used when creating a change tracking context or a sharded context.
+        /// </summary>
+        /// <param name="dbContextOptionsFunc">
+        /// A <see cref="Func{TResult}"/> that accepts the connection string and returns a <see cref="DbContextOptions"/>
+        /// </param>
+        /// <example>
+        /// <code>
+        /// ef.AddEntity<Guid, WeatherForecast>(forecast =>
+        ///    forecast.WithDbContext<AppDbContext>()
+        ///        .WithDbOptionsProvider(new DbContextOptionsBuilder().AddSqlServer().Options)
+        ///        .AddCrud()
+        ///        .AddControllers()
+        /// </code>
+        /// </example>
+        public EntityFrameworkEntityBuilder<TKey, TEntity> WithDbOptionsProvider(Func<string, DbContextOptions> dbContextOptionsFunc)
+        {
+            WithRegistrationInstance<IDbContextOptionsProvider<TKey, TEntity>>(new DbContextOptionsProvider<TKey, TEntity>(dbContextOptionsFunc));
             return this;
         }
     }

--- a/Firebend.AutoCrud.EntityFramework/Firebend.AutoCrud.EntityFramework.csproj
+++ b/Firebend.AutoCrud.EntityFramework/Firebend.AutoCrud.EntityFramework.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.EntityFramework/Firebend.AutoCrud.EntityFramework.csproj
+++ b/Firebend.AutoCrud.EntityFramework/Firebend.AutoCrud.EntityFramework.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.EntityFramework/Interfaces/IDbContextOptionsProvider.cs
+++ b/Firebend.AutoCrud.EntityFramework/Interfaces/IDbContextOptionsProvider.cs
@@ -1,0 +1,9 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Firebend.AutoCrud.EntityFramework.Interfaces
+{
+    public interface IDbContextOptionsProvider<TKey, TEntity>
+    {
+        DbContextOptions GetDbContextOptions(string connectionString);
+    }
+}

--- a/Firebend.AutoCrud.EntityFramework/Interfaces/IDbContextProvider.cs
+++ b/Firebend.AutoCrud.EntityFramework/Interfaces/IDbContextProvider.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Firebend.AutoCrud.Core.Interfaces.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace Firebend.AutoCrud.EntityFramework.Interfaces
 {

--- a/Firebend.AutoCrud.Generator/Firebend.AutoCrud.Generator.csproj
+++ b/Firebend.AutoCrud.Generator/Firebend.AutoCrud.Generator.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Generator/Firebend.AutoCrud.Generator.csproj
+++ b/Firebend.AutoCrud.Generator/Firebend.AutoCrud.Generator.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Io.Web/Firebend.AutoCrud.Io.Web.csproj
+++ b/Firebend.AutoCrud.Io.Web/Firebend.AutoCrud.Io.Web.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Io.Web/Firebend.AutoCrud.Io.Web.csproj
+++ b/Firebend.AutoCrud.Io.Web/Firebend.AutoCrud.Io.Web.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Io/Extensions.cs
+++ b/Firebend.AutoCrud.Io/Extensions.cs
@@ -17,7 +17,7 @@ namespace Firebend.AutoCrud.Io
         ///  .ConfigureServices((hostContext, services) => {
         ///      services.UsingEfCrud(ef =>
         ///     {
-        ///         ef.AddEntity<Guid, WeatherForecast>(forecast => 
+        ///         ef.AddEntity<Guid, WeatherForecast>(forecast =>
         ///             forecast.WithDbContext<AppDbContext>()
         ///                 .AddCrud()
         ///                 .AddIo(io => io.WithMapper(x => new WeatherForecastExport(x)))
@@ -32,7 +32,6 @@ namespace Firebend.AutoCrud.Io
         ///     })
         /// </code>
         /// </example>
-        /// See <see cref="" />
         public static EntityCrudBuilder<TKey, TEntity> AddIo<TKey, TEntity>(this EntityCrudBuilder<TKey, TEntity> builder,
             Action<IoConfigurator<EntityCrudBuilder<TKey, TEntity>, TKey, TEntity>> configure = null)
             where TKey : struct

--- a/Firebend.AutoCrud.Io/Firebend.AutoCrud.Io.csproj
+++ b/Firebend.AutoCrud.Io/Firebend.AutoCrud.Io.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Io/Firebend.AutoCrud.Io.csproj
+++ b/Firebend.AutoCrud.Io/Firebend.AutoCrud.Io.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Mongo/Firebend.AutoCrud.Mongo.csproj
+++ b/Firebend.AutoCrud.Mongo/Firebend.AutoCrud.Mongo.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Mongo/Firebend.AutoCrud.Mongo.csproj
+++ b/Firebend.AutoCrud.Mongo/Firebend.AutoCrud.Mongo.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Web.Sample/DbContexts/PersonDbContext.cs
+++ b/Firebend.AutoCrud.Web.Sample/DbContexts/PersonDbContext.cs
@@ -1,23 +1,13 @@
-using Firebend.AutoCrud.EntityFramework.Elastic.CustomCommands;
 using Firebend.AutoCrud.EntityFramework.Interfaces;
 using Firebend.AutoCrud.Web.Sample.Models;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace Firebend.AutoCrud.Web.Sample.DbContexts
 {
     public class PersonDbContext : DbContext, IDbContext
     {
-        private static DbContextOptions GetOptions()
-        {
-            var connString = DataAccessConfiguration.GetConfiguration().GetConnectionString("InventoryElasticPool");
 
-            return new DbContextOptionsBuilder()
-                .UseSqlServer(connString)
-                .Options;
-        }
-        public PersonDbContext() : base(GetOptions())
+        public PersonDbContext() : base(PersonDbContextOptions.GetOptions())
         {
         }
 
@@ -28,17 +18,5 @@ namespace Firebend.AutoCrud.Web.Sample.DbContexts
         public DbSet<EfPerson> People { get; set; }
 
         public DbSet<EfPet> Pets { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            optionsBuilder
-                .UseLoggerFactory(
-                    LoggerFactory.Create(c => c.AddConsole()))
-                .EnableSensitiveDataLogging()
-                .AddFirebendFunctions()
-                ;
-
-            base.OnConfiguring(optionsBuilder);
-        }
     }
 }

--- a/Firebend.AutoCrud.Web.Sample/DbContexts/PersonDbContextOptions.cs
+++ b/Firebend.AutoCrud.Web.Sample/DbContexts/PersonDbContextOptions.cs
@@ -1,0 +1,20 @@
+using Firebend.AutoCrud.EntityFramework.Elastic.CustomCommands;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Firebend.AutoCrud.Web.Sample.DbContexts
+{
+    public static class PersonDbContextOptions
+    {
+        public static DbContextOptions GetOptions() => GetOptions(DataAccessConfiguration.GetConfiguration().GetConnectionString("InventoryElasticPool"));
+
+        public static DbContextOptions GetOptions(string connectionString) => new DbContextOptionsBuilder()
+            .UseSqlServer(connectionString)
+            .AddFirebendFunctions()
+            .UseLoggerFactory(
+                LoggerFactory.Create(c => c.AddConsole()))
+            .EnableSensitiveDataLogging()
+            .Options;
+    }
+}

--- a/Firebend.AutoCrud.Web.Sample/Extensions/SampleEntityExtensions.cs
+++ b/Firebend.AutoCrud.Web.Sample/Extensions/SampleEntityExtensions.cs
@@ -50,6 +50,7 @@ namespace Firebend.AutoCrud.Web.Sample.Extensions
             IConfiguration configuration) =>
             generator.AddEntity<Guid, EfPerson>(person =>
                 person.WithDbContext<PersonDbContext>()
+                    .WithDbOptionsProvider(PersonDbContextOptions.GetOptions)
                     .WithSearchFilter((efPerson, s) => EF.Functions.ContainsAny(efPerson.FirstName, s))
                     .AddElasticPool(manager =>
                         {
@@ -57,8 +58,7 @@ namespace Firebend.AutoCrud.Web.Sample.Extensions
                             manager.MapName = configuration["Elastic:MapName"];
                             manager.Server = configuration["Elastic:ServerName"];
                             manager.ElasticPoolName = configuration["Elastic:PoolName"];
-                        }, pool => pool
-                            .WithShardKeyProvider<SampleKeyProvider>()
+                        }, pool => pool.WithShardKeyProvider<SampleKeyProvider>()
                             .WithShardDbNameProvider<SampleDbNameProvider>()
                     )
                     .AddCrud(crud => crud
@@ -100,9 +100,8 @@ namespace Firebend.AutoCrud.Web.Sample.Extensions
                     .WithSearchFilter((efPet, s) => efPet.PetName.Contains(s) ||
                                                     efPet.PetType.Contains(s) ||
                                                     EF.Functions.ContainsAny(efPet.Person.FirstName, s)
-                                                    //efPet.Person.LastName.Contains(s) ||
-                                                    //efPet.Person.FirstName.Contains(s)
                                                     )
+                    .WithDbOptionsProvider(PersonDbContextOptions.GetOptions)
                     .WithIncludes(pets => pets.Include(p => p.Person))
                     .AddElasticPool(manager =>
                         {
@@ -110,8 +109,7 @@ namespace Firebend.AutoCrud.Web.Sample.Extensions
                             manager.MapName = configuration["Elastic:MapName"];
                             manager.Server = configuration["Elastic:ServerName"];
                             manager.ElasticPoolName = configuration["Elastic:PoolName"];
-                        }, pool => pool
-                            .WithShardKeyProvider<SampleKeyProvider>()
+                        }, pool => pool.WithShardKeyProvider<SampleKeyProvider>()
                             .WithShardDbNameProvider<SampleDbNameProvider>()
                     )
                     .AddCrud(crud => crud

--- a/Firebend.AutoCrud.Web.Sample/sample.ef.pets.http
+++ b/Firebend.AutoCrud.Web.Sample/sample.ef.pets.http
@@ -1,4 +1,4 @@
-POST https://localhost:5001/api/v1/ef-person/a2f9d44a-613c-42d2-41d3-08d884ca630d/pets
+POST https://localhost:5001/api/v1/ef-person/cf8f6e10-c203-465b-20f5-08d8b65581d6/pets
 Content-Type: application/json
 
 {
@@ -6,7 +6,10 @@ Content-Type: application/json
     "petType": "Dog"
 }
 ###
-GET https://localhost:5001/api/v1/ef-person/5eaa2c79-5709-43bb-9768-08d88bd03ee0/pets?pageNumber=1&pageSize=10
+GET https://localhost:5001/api/v1/ef-person/cf8f6e10-c203-465b-20f5-08d8b65581d6/pets?pageNumber=1&pageSize=10
 
 ###
-GET https://localhost:5001/api/v1/ef-person/5eaa2c79-5709-43bb-9768-08d88bd03ee0/pets/export/csv?pageNumber=1&pageSize=10&fileName=test
+GET https://localhost:5001/api/v1/ef-person/cf8f6e10-c203-465b-20f5-08d8b65581d6/pets/1b3e5104-3e6c-4707-2fe0-08d8b6558ebc/changes?pageNumber=1&pageSize=10
+
+###
+GET https://localhost:5001/api/v1/ef-person/cf8f6e10-c203-465b-20f5-08d8b65581d6/pets/export/csv?pageNumber=1&pageSize=10&fileName=test

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityCreateController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityCreateController.cs
@@ -37,7 +37,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
         [SwaggerResponse(201, "A {entityName} was created successfully..")]
         [SwaggerResponse(400, "The request is invalid.")]
         [Produces("application/json")]
-        public virtual async Task<IActionResult> Post(
+        public virtual async Task<ActionResult<TReadViewModel>> Post(
              TCreateViewModel body,
             CancellationToken cancellationToken)
         {

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityCreateMultipleController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityCreateMultipleController.cs
@@ -115,7 +115,8 @@ namespace Firebend.AutoCrud.Web.Abstractions
             {
                 return Ok(new CreateMultipleActionResult<TEntity, TReadViewModel>
                 {
-                    Created = createdEntities, Errors = errorEntities
+                    Created = createdEntities,
+                    Errors = errorEntities
                 });
             }
 

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityCreateMultipleController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityCreateMultipleController.cs
@@ -7,6 +7,7 @@ using Firebend.AutoCrud.Core.Interfaces.Models;
 using Firebend.AutoCrud.Core.Interfaces.Services.Entities;
 using Firebend.AutoCrud.Core.Models.Entities;
 using Firebend.AutoCrud.Web.Interfaces;
+using Firebend.AutoCrud.Web.Models;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -41,7 +42,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
         [SwaggerResponse(201, "Multiple {entityNamePlural} were created successfully.")]
         [SwaggerResponse(400, "The request is invalid.")]
         [Produces("application/json")]
-        public virtual async Task<IActionResult> PostMultiple(
+        public virtual async Task<ActionResult<CreateMultipleActionResult<TEntity, TReadViewModel>>> PostMultiple(
             TMultipleViewModelWrapper body,
             CancellationToken cancellationToken)
         {
@@ -112,7 +113,10 @@ namespace Firebend.AutoCrud.Web.Abstractions
 
             if (createdEntities.Count > 0)
             {
-                return Ok(new { created = createdEntities, errors = errorEntities });
+                return Ok(new CreateMultipleActionResult<TEntity, TReadViewModel>
+                {
+                    Created = createdEntities, Errors = errorEntities
+                });
             }
 
             if (errorEntities.Count > 0)

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityDeleteController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityDeleteController.cs
@@ -32,7 +32,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
         [SwaggerResponse(404, "The {entityName} with the given key is not found.")]
         [SwaggerResponse(400, "The request is invalid.")]
         [Produces("application/json")]
-        public virtual async Task<IActionResult> Delete(
+        public virtual async Task<ActionResult<TViewModel>> Delete(
             [Required][FromRoute] string id,
             CancellationToken cancellationToken)
         {

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityReadAllController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityReadAllController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,7 +30,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
         [SwaggerOperation("Gets all {entityNamePlural}")]
         [SwaggerResponse(200, "All the {entityNamePlural}.")]
         [SwaggerResponse(400, "The request is invalid.")]
-        public virtual async Task<IActionResult> GetAll(CancellationToken cancellationToken)
+        public virtual async Task<ActionResult<IEnumerable<TViewModel>>> GetAll(CancellationToken cancellationToken)
         {
             var entities = await _readService
                 .GetAllAsync(cancellationToken)

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityReadController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityReadController.cs
@@ -31,7 +31,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
         [SwaggerResponse(200, "The {entityName} with the given key.")]
         [SwaggerResponse(404, "The {entityName} with the given key is not found.")]
         [Produces("application/json")]
-        public virtual async Task<IActionResult> GetById(
+        public virtual async Task<ActionResult<TViewModel>> GetById(
             [Required][FromRoute] string id,
             CancellationToken cancellationToken)
         {

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntitySearchController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntitySearchController.cs
@@ -35,7 +35,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
         [SwaggerOperation("Searches for {entityNamePlural}")]
         [SwaggerResponse(200, "All the {entityNamePlural} that match the search criteria.")]
         [SwaggerResponse(400, "The request is invalid.")]
-        public virtual async Task<IActionResult> Search(
+        public virtual async Task<ActionResult<EntityPagedResponse<TViewModel>>> Search(
             [FromQuery] TSearch searchRequest,
             CancellationToken cancellationToken)
         {

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityUpdateController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityUpdateController.cs
@@ -45,7 +45,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
         [SwaggerResponse(404, "The {entityName} with the given key is not found.")]
         [SwaggerResponse(400, "The request is invalid.")]
         [Produces("application/json")]
-        public virtual async Task<IActionResult> Put(
+        public virtual async Task<ActionResult<TReadViewModel>> Put(
             [Required][FromRoute] string id,
             [Required] TUpdateViewModel body,
             CancellationToken cancellationToken)
@@ -134,7 +134,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
         [SwaggerResponse(404, "The {entityName} with the given key is not found.")]
         [SwaggerResponse(400, "The request is invalid.")]
         [Produces("application/json")]
-        public virtual async Task<IActionResult> Patch(
+        public virtual async Task<ActionResult<TReadViewModel>> Patch(
             [Required][FromRoute] string id,
             [Required][FromBody] JsonPatchDocument<TEntity> patch,
             CancellationToken cancellationToken)

--- a/Firebend.AutoCrud.Web/Firebend.AutoCrud.Web.csproj
+++ b/Firebend.AutoCrud.Web/Firebend.AutoCrud.Web.csproj
@@ -2,9 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Version>0.0.28</Version>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
+        <Version>0.0.29</Version>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -16,10 +14,6 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Web/Firebend.AutoCrud.Web.csproj
+++ b/Firebend.AutoCrud.Web/Firebend.AutoCrud.Web.csproj
@@ -3,6 +3,8 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Version>0.0.28</Version>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591;CS1570;EF1001;CS1572;CS1573</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,6 +16,10 @@
       <PackageLicenseUrl>https://github.com/firebend/auto-crud/blob/main/LICENSE</PackageLicenseUrl>
       <PackageProjectUrl>https://github.com/firebend/auto-crud</PackageProjectUrl>
       <PackageIconUrl>https://github.com/firebend/auto-crud/blob/main/nuget-image.png?raw=true</PackageIconUrl>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Web/Models/CreateMultipleActionResult.cs
+++ b/Firebend.AutoCrud.Web/Models/CreateMultipleActionResult.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Firebend.AutoCrud.Core.Models.Entities;
+
+namespace Firebend.AutoCrud.Web.Models
+{
+    public class CreateMultipleActionResult<TEntity, TViewModel>
+    {
+        public List<TViewModel> Created { get; set; }
+
+        public List<ModelStateResult<TEntity>> Errors { get; set; }
+    }
+}


### PR DESCRIPTION
* fixes issues with swagger/swashbuckle not knowing the return types of endpoints
   * done so by changing `IActionResult` to `ActionResult<TModel>`
* adds a new `IDbContextOptionsProvider`
   * allows you can specify how to set options for db contexts in change tracking and shards