### PR TITLE
auto mapper update

### DIFF
--- a/Firebend.AutoCrud.Core/Extensions/ObjectExtensions.cs
+++ b/Firebend.AutoCrud.Core/Extensions/ObjectExtensions.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using System.Linq;
+using Firebend.AutoCrud.Core.ObjectMapping;
 using Newtonsoft.Json;
 
 namespace Firebend.AutoCrud.Core.Extensions
@@ -37,34 +37,7 @@ namespace Firebend.AutoCrud.Core.Extensions
 
         public static TU CopyPropertiesTo<T, TU>(this T source, TU dest, params string[] propertiesToIgnore)
         {
-            var sourceProps = typeof(T)
-                .GetProperties()
-                .Where(x => x.CanRead)
-                .ToList();
-
-            var destProps = typeof(TU)
-                .GetProperties()
-                .Where(x => x.CanWrite)
-                .ToList();
-
-            foreach (var sourceProp in sourceProps)
-            {
-                if (propertiesToIgnore != null && sourceProp.Name.In(propertiesToIgnore))
-                {
-                    continue;
-                }
-
-                if (destProps.Any(x => x.Name == sourceProp.Name && x.PropertyType == sourceProp.PropertyType))
-                {
-                    var p = destProps.First(x => x.Name == sourceProp.Name);
-
-                    if (p.CanWrite)
-                    {
-                        p.SetValue(dest, sourceProp.GetValue(source, null), null);
-                    }
-                }
-            }
-
+            ObjectMapper.Instance.Copy(source, dest);
             return dest;
         }
     }

--- a/Firebend.AutoCrud.Core/Extensions/ObjectExtensions.cs
+++ b/Firebend.AutoCrud.Core/Extensions/ObjectExtensions.cs
@@ -37,7 +37,7 @@ namespace Firebend.AutoCrud.Core.Extensions
 
         public static TU CopyPropertiesTo<T, TU>(this T source, TU dest, params string[] propertiesToIgnore)
         {
-            ObjectMapper.Instance.Copy(source, dest);
+            ObjectMapper.Instance.Copy(source, dest, propertiesToIgnore);
             return dest;
         }
     }

--- a/Firebend.AutoCrud.Core/ObjectMapping/BaseObjectMapper.cs
+++ b/Firebend.AutoCrud.Core/ObjectMapping/BaseObjectMapper.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Firebend.AutoCrud.Core.ObjectMapping
+{
+    public abstract class BaseObjectMapper
+    {
+
+        protected abstract void MapTypes(Type source, Type target);
+        public abstract void Copy(object source, object target);
+
+        /// <summary>
+        /// This virtual function finds matching properties between given objects. It depends on their names, readability, and writability.
+        /// </summary>
+        /// <param name="sourceType">The source object's type</param>
+        /// <param name="targetType">The target object's type</param>
+        /// <returns>Returns a list of PropertyMap.</returns>
+        protected virtual IEnumerable<PropertyMap> GetMatchingProperties
+            (Type sourceType, Type targetType)
+        {
+            var sourceProperties = sourceType.GetProperties();
+            var targetProperties = targetType.GetProperties();
+
+            var properties = (from s in sourceProperties
+                from t in targetProperties
+                where s.Name == t.Name &&
+                      s.CanRead &&
+                      t.CanWrite
+                select new PropertyMap
+                {
+                    SourceProperty = s,
+                    TargetProperty = t
+                }).ToList();
+            return properties;
+        }
+
+        /// <summary>
+        /// This virtual function builds a key to identify the converter method. It uses object names and combines them with defined pattern.
+        /// </summary>
+        /// <param name="sourceType">The source object type</param>
+        /// <param name="targetType">The target object type</param>
+        /// <returns>Returns a key as string</returns>
+        /// <exception cref="Exception">If there is no FullName property on sent objects, an exception will throw</exception>
+        protected virtual string GetMapKey(Type sourceType, Type targetType)
+        {
+            var keyName = "Copy_";
+
+            if (sourceType.FullName != null)
+            {
+                keyName += sourceType.FullName.Replace(".", "_").Replace("+", "_");
+                keyName += "_";
+            }
+            else
+            {
+                throw new Exception();
+            }
+
+            if (targetType.FullName != null)
+            {
+                keyName += targetType.FullName.Replace(".", "_").Replace("+", "_");
+            }
+            else
+            {
+                throw new Exception();
+            }
+
+            return keyName;
+        }
+    }
+}

--- a/Firebend.AutoCrud.Core/ObjectMapping/BaseObjectMapper.cs
+++ b/Firebend.AutoCrud.Core/ObjectMapping/BaseObjectMapper.cs
@@ -42,7 +42,7 @@ namespace Firebend.AutoCrud.Core.ObjectMapping
         /// <param name="targetType">The target object type</param>
         /// <returns>Returns a key as string</returns>
         /// <exception cref="Exception">If there is no FullName property on sent objects, an exception will throw</exception>
-        protected virtual string GetMapKey(Type sourceType, Type targetType)
+        protected virtual string GetMapKey(Type sourceType, Type targetType, params string[] propertiesToIgnore)
         {
             var keyName = "Copy_";
 
@@ -63,6 +63,11 @@ namespace Firebend.AutoCrud.Core.ObjectMapping
             else
             {
                 throw new Exception();
+            }
+
+            if (propertiesToIgnore != null)
+            {
+                keyName = propertiesToIgnore.Aggregate(keyName, (current, t) => current + $"_{t}");
             }
 
             return keyName;

--- a/Firebend.AutoCrud.Core/ObjectMapping/BaseObjectMapper.cs
+++ b/Firebend.AutoCrud.Core/ObjectMapping/BaseObjectMapper.cs
@@ -7,8 +7,8 @@ namespace Firebend.AutoCrud.Core.ObjectMapping
     public abstract class BaseObjectMapper
     {
 
-        protected abstract void MapTypes(Type source, Type target);
-        public abstract void Copy(object source, object target);
+        protected abstract string MapTypes(Type source, Type target, params string[] propertiesToIgnore);
+        public abstract void Copy(object source, object target, params string[] propertiesToIgnore);
 
         /// <summary>
         /// This virtual function finds matching properties between given objects. It depends on their names, readability, and writability.

--- a/Firebend.AutoCrud.Core/ObjectMapping/BaseObjectMapper.cs
+++ b/Firebend.AutoCrud.Core/ObjectMapping/BaseObjectMapper.cs
@@ -23,15 +23,15 @@ namespace Firebend.AutoCrud.Core.ObjectMapping
             var targetProperties = targetType.GetProperties();
 
             var properties = (from s in sourceProperties
-                from t in targetProperties
-                where s.Name == t.Name &&
-                      s.CanRead &&
-                      t.CanWrite
-                select new PropertyMap
-                {
-                    SourceProperty = s,
-                    TargetProperty = t
-                }).ToList();
+                              from t in targetProperties
+                              where s.Name == t.Name &&
+                                    s.CanRead &&
+                                    t.CanWrite
+                              select new PropertyMap
+                              {
+                                  SourceProperty = s,
+                                  TargetProperty = t
+                              }).ToList();
             return properties;
         }
 

--- a/Firebend.AutoCrud.Core/ObjectMapping/ObjectMapper.cs
+++ b/Firebend.AutoCrud.Core/ObjectMapping/ObjectMapper.cs
@@ -31,12 +31,7 @@ namespace Firebend.AutoCrud.Core.ObjectMapping
         /// <exception cref="InvalidOperationException">The Invalid Operation Exception will be thrown if it can't find the given property in source/target objects.</exception>
         protected override string MapTypes(Type source, Type target, params string[] propertiesToIgnore)
         {
-            var key = GetMapKey(source, target);
-
-            if (propertiesToIgnore.Length > 0)
-            {
-                key = $"{Guid.NewGuid()}_{key}";
-            }
+            var key = GetMapKey(source, target, propertiesToIgnore);
 
             if (_del.ContainsKey(key))
             {
@@ -83,11 +78,6 @@ namespace Firebend.AutoCrud.Core.ObjectMapping
             var del = _del[key];
             var args = new[] { source, target };
             del.Invoke(null, args);
-
-            if (propertiesToIgnore.Length > 0)
-            {
-                _del.Remove(key);
-            }
         }
     }
 }

--- a/Firebend.AutoCrud.Core/ObjectMapping/ObjectMapper.cs
+++ b/Firebend.AutoCrud.Core/ObjectMapping/ObjectMapper.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+
+namespace Firebend.AutoCrud.Core.ObjectMapping
+{
+    /// <summary>
+    /// This mapper class finds the matching properties and copies them from source object to target object. The copy function has IL codes to do this task.
+    /// </summary>
+    public class ObjectMapper : BaseObjectMapper
+    {
+        /// <summary>
+        /// Easy access to mapper functions
+        /// </summary>
+        public static ObjectMapper Instance { get; protected set; } = new ObjectMapper();
+
+        private ObjectMapper() { }
+
+        /// <summary>
+        /// This dictionary keeps the convert functions for objects by auto generated names
+        /// </summary>
+        private readonly Dictionary<string, DynamicMethod> _del = new Dictionary<string, DynamicMethod>();
+
+        /// <summary>
+        /// This function creates the mappings between objects and store the mappings in the private dictionary
+        /// </summary>
+        /// <param name="source">Type of the source object</param>
+        /// <param name="target">Type of the target object</param>
+        /// <exception cref="InvalidOperationException">The Invalid Operation Exception will be thrown if it can't find the given property in source/target objects.</exception>
+        protected override void MapTypes(Type source, Type target)
+        {
+            var key = GetMapKey(source, target);
+            if (_del.ContainsKey(key))
+            {
+                return;
+            }
+
+            var args = new[] { source, target };
+
+            var dm = new DynamicMethod(key, null, args);
+            var il = dm.GetILGenerator();
+            var maps = GetMatchingProperties(source, target);
+
+            foreach (var map in maps)
+            {
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldarg_0);
+                il.EmitCall(OpCodes.Callvirt, map.SourceProperty.GetGetMethod() ?? throw new InvalidOperationException(), null);
+                il.EmitCall(OpCodes.Callvirt, map.TargetProperty.GetSetMethod() ?? throw new InvalidOperationException(), null);
+            }
+            il.Emit(OpCodes.Ret);
+            _del.Add(key, dm);
+        }
+
+        /// <summary>
+        /// This function copies all matched property values from source object to target object
+        /// </summary>
+        /// <param name="source">The original object that keeps the actual values/properties</param>
+        /// <param name="target">The object that will get the related values from the given object</param>
+        public override void Copy(object source, object target)
+        {
+            var sourceType = source.GetType();
+            var targetType = target.GetType();
+
+            this.MapTypes(sourceType, targetType);
+
+            var key = GetMapKey(sourceType, targetType);
+
+            var del = _del[key];
+            var args = new[] { source, target };
+            del.Invoke(null, args);
+        }
+    }
+}

--- a/Firebend.AutoCrud.Core/ObjectMapping/ObjectMapper.cs
+++ b/Firebend.AutoCrud.Core/ObjectMapping/ObjectMapper.cs
@@ -35,7 +35,7 @@ namespace Firebend.AutoCrud.Core.ObjectMapping
 
             if (propertiesToIgnore.Length > 0)
             {
-                key = $"temp_{key}";
+                key = $"{Guid.NewGuid()}_{key}";
             }
 
             if (_del.ContainsKey(key))

--- a/Firebend.AutoCrud.Core/ObjectMapping/PropertyMap.cs
+++ b/Firebend.AutoCrud.Core/ObjectMapping/PropertyMap.cs
@@ -1,0 +1,13 @@
+using System.Reflection;
+
+namespace Firebend.AutoCrud.Core.ObjectMapping
+{
+    /// <summary>
+    /// This class is created for holding source and target 
+    /// </summary>
+    public class PropertyMap
+    {
+        public PropertyInfo SourceProperty { get; set; }
+        public PropertyInfo TargetProperty { get; set; }
+    }
+}

--- a/Firebend.AutoCrud.Tests/Core/ObjectMappingTests.cs
+++ b/Firebend.AutoCrud.Tests/Core/ObjectMappingTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using Firebend.AutoCrud.Core.ObjectMapping;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Firebend.AutoCrud.Tests.Core
+{
+    [TestFixture]
+    public class MapperTests
+    {
+        [TestCase]
+        public void Mapper_Should_Map_Primitive_Type_Props()
+        {
+            // given
+            var givenSourceObj = new MapperTestObjClass
+            {
+                Name = "Prime Jedi",
+                Age = 4500,
+                Birthdate = DateTime.Now.AddYears(1000),
+                IsJedi = true
+            };
+            var givenTargetObj = new MapperTestObjClass();
+
+            // when
+            ObjectMapper.Instance.Copy(givenSourceObj, givenTargetObj);
+
+            // then
+            givenTargetObj.Should().NotBeNull();
+            givenTargetObj.Name.Should().Be(givenSourceObj.Name);
+            givenTargetObj.Age.Should().Be(givenSourceObj.Age);
+            givenTargetObj.Birthdate.Should().Be(givenSourceObj.Birthdate);
+            givenTargetObj.IsJedi.Should().Be(givenSourceObj.IsJedi);
+        }
+
+        [TestCase]
+        public void Mapper_Should_Map_Objects_With_Lists()
+        {
+            // given
+            var givenSourceObj = new MapperTestObjWithListClass
+            {
+                Name = "Ahsoka Tano",
+                Enemies = new List<MapperTestObjClass>
+                {
+                    new MapperTestObjClass
+                    {
+                        Name = "Darth Maul",
+                        Age = 54,
+                        Birthdate = DateTime.Now.AddYears(1000),
+                        IsJedi = false
+                    },
+                    new MapperTestObjClass
+                    {
+                        Name = "Darth Sidious",
+                        Age = 84,
+                        Birthdate = DateTime.Now.AddYears(5000),
+                        IsJedi = false
+                    },
+                }
+            };
+            var givenTargetObj = new MapperTestObjWithListClass();
+
+            // when
+            ObjectMapper.Instance.Copy(givenSourceObj, givenTargetObj);
+
+            // then
+            givenTargetObj.Should().NotBeNull();
+
+            givenTargetObj.Name.Should().Be(givenSourceObj.Name);
+
+            givenTargetObj.Enemies.Should().NotBeNull();
+            givenTargetObj.Enemies.Count.Should()
+                .Be(givenSourceObj.Enemies.Count);
+            givenTargetObj.Enemies[0].Name.Should()
+                .Be(givenSourceObj.Enemies[0].Name);
+        }
+
+        [TestCase]
+        public void Mapper_Should_Map_Objects_By_Different_Types()
+        {
+            // given
+            var givenSourceObj = new MapperTestObjClass
+            {
+                Name = "Prime Jedi",
+                Age = 4500,
+                Birthdate = DateTime.Now.AddYears(1000),
+                IsJedi = true
+            };
+            var givenTargetObj = new MapperTestAnotherObjClass();
+
+            // when
+            ObjectMapper.Instance.Copy(givenSourceObj, givenTargetObj);
+
+            // then
+            givenTargetObj.Should().NotBeNull();
+            givenTargetObj.Name.Should().Be(givenSourceObj.Name);
+            givenTargetObj.Age.Should().Be(givenSourceObj.Age);
+            givenTargetObj.Birthdate.Should().Be(givenSourceObj.Birthdate);
+            givenTargetObj.IsJedi.Should().Be(givenSourceObj.IsJedi);
+        }
+
+        [TestCase]
+        public void Mapper_Should_Map_Objects_By_Different_Types_With_Lists()
+        {
+            // given
+            var givenSourceObj = new MapperTestObjWithListClass
+            {
+                Name = "Ahsoka Tano",
+                Enemies = new List<MapperTestObjClass>
+                {
+                    new MapperTestObjClass
+                    {
+                        Name = "Darth Maul",
+                        Age = 54,
+                        Birthdate = DateTime.Now.AddYears(1000),
+                        IsJedi = false
+                    },
+                    new MapperTestObjClass
+                    {
+                        Name = "Darth Sidious",
+                        Age = 84,
+                        Birthdate = DateTime.Now.AddYears(5000),
+                        IsJedi = false
+                    },
+                }
+            };
+            var givenTargetObj = new MapperTestAnotherObjWithListClass();
+
+            // when
+            ObjectMapper.Instance.Copy(givenSourceObj, givenTargetObj);
+
+            // then
+            givenTargetObj.Should().NotBeNull();
+
+            givenTargetObj.Name.Should().Be(givenSourceObj.Name);
+
+            givenTargetObj.Enemies.Should().NotBeNull();
+            givenTargetObj.Enemies.Count.Should()
+                .Be(givenSourceObj.Enemies.Count);
+            givenTargetObj.Enemies[0].Name.Should()
+                .Be(givenSourceObj.Enemies[0].Name);
+        }
+    }
+
+    internal class MapperTestObjClass
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+        public DateTime Birthdate { get; set; }
+        public bool IsJedi { get; set; }
+    }
+
+    internal class MapperTestObjWithListClass
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+        public DateTime Birthdate { get; set; }
+        public List<MapperTestObjClass> Enemies { get; set; }
+    }
+
+    internal class MapperTestAnotherObjClass
+    {
+        public string Name { get; set; }
+        public int Age { get; set; }
+        public DateTime Birthdate { get; set; }
+        public bool IsJedi { get; set; }
+    }
+
+    internal class MapperTestAnotherObjWithListClass
+    {
+        public string Name { get; set; }
+        public List<MapperTestAnotherObjClass> Enemies { get; set; }
+    }
+}

--- a/Firebend.AutoCrud.Tests/Core/ObjectMappingTests.cs
+++ b/Firebend.AutoCrud.Tests/Core/ObjectMappingTests.cs
@@ -11,7 +11,7 @@ namespace Firebend.AutoCrud.Tests.Core
     {
         [TestCase]
         public void
-            Mapper_Should_Create_Temp_Mapping_For_Objects_With_Ignored_Properties()
+            Mapper_Should_Not_Copy_Of_Ignored_Properties_After_Full_Copy_Operation()
         {
             // given
             var givenSourceObj = new MapperTestObjClass

--- a/Firebend.AutoCrud.Tests/Core/ObjectMappingTests.cs
+++ b/Firebend.AutoCrud.Tests/Core/ObjectMappingTests.cs
@@ -10,6 +10,32 @@ namespace Firebend.AutoCrud.Tests.Core
     public class MapperTests
     {
         [TestCase]
+        public void Mapper_Should_Map_Primitive_Type_Props_Without_Ignored_Props()
+        {
+            // given
+            var givenSourceObj = new MapperTestObjClass
+            {
+                Name = "Prime Jedi",
+                Age = 4500,
+                Birthdate = DateTime.Now.AddYears(1000),
+                IsJedi = true
+            };
+            var givenTargetObj = new MapperTestObjClass();
+
+            // when
+            ObjectMapper.Instance.Copy(givenSourceObj, givenTargetObj, "Age", "Name");
+
+            // then
+            var expectedAge = 0;
+
+            givenTargetObj.Should().NotBeNull();
+            givenTargetObj.Name.Should().BeNull();
+            givenTargetObj.Age.Should().Be(expectedAge);
+            givenTargetObj.Birthdate.Should().Be(givenSourceObj.Birthdate);
+            givenTargetObj.IsJedi.Should().Be(givenSourceObj.IsJedi);
+        }
+
+        [TestCase]
         public void Mapper_Should_Map_Primitive_Type_Props()
         {
             // given

--- a/Firebend.AutoCrud.Tests/Core/ObjectMappingTests.cs
+++ b/Firebend.AutoCrud.Tests/Core/ObjectMappingTests.cs
@@ -23,10 +23,12 @@ namespace Firebend.AutoCrud.Tests.Core
             };
             var givenTargetObj = new MapperTestObjClass();
             var givenTargetObjWithIgnoredProperties = new MapperTestObjClass();
+            var givenTargetObjWithDifferentIgnoredProperties = new MapperTestObjClass();
 
             // when
             ObjectMapper.Instance.Copy(givenSourceObj, givenTargetObj);
             ObjectMapper.Instance.Copy(givenSourceObj, givenTargetObjWithIgnoredProperties, "Age", "Name");
+            ObjectMapper.Instance.Copy(givenSourceObj, givenTargetObjWithDifferentIgnoredProperties, "Age");
 
             // then
             var expectedAge = 0;
@@ -36,6 +38,9 @@ namespace Firebend.AutoCrud.Tests.Core
             givenTargetObjWithIgnoredProperties.Age.Should().Be(expectedAge);
             givenTargetObjWithIgnoredProperties.Birthdate.Should().Be(givenSourceObj.Birthdate);
             givenTargetObjWithIgnoredProperties.IsJedi.Should().Be(givenSourceObj.IsJedi);
+
+            givenTargetObjWithDifferentIgnoredProperties.Name.Should().Be(givenSourceObj.Name);
+            givenTargetObjWithDifferentIgnoredProperties.Age.Should().Be(expectedAge);
         }
 
         [TestCase]

--- a/Firebend.AutoCrud.Tests/Core/ObjectMappingTests.cs
+++ b/Firebend.AutoCrud.Tests/Core/ObjectMappingTests.cs
@@ -10,6 +10,35 @@ namespace Firebend.AutoCrud.Tests.Core
     public class MapperTests
     {
         [TestCase]
+        public void
+            Mapper_Should_Create_Temp_Mapping_For_Objects_With_Ignored_Properties()
+        {
+            // given
+            var givenSourceObj = new MapperTestObjClass
+            {
+                Name = "Prime Jedi",
+                Age = 4500,
+                Birthdate = DateTime.Now.AddYears(1000),
+                IsJedi = true
+            };
+            var givenTargetObj = new MapperTestObjClass();
+            var givenTargetObjWithIgnoredProperties = new MapperTestObjClass();
+
+            // when
+            ObjectMapper.Instance.Copy(givenSourceObj, givenTargetObj);
+            ObjectMapper.Instance.Copy(givenSourceObj, givenTargetObjWithIgnoredProperties, "Age", "Name");
+
+            // then
+            var expectedAge = 0;
+
+            givenTargetObjWithIgnoredProperties.Should().NotBeNull();
+            givenTargetObjWithIgnoredProperties.Name.Should().BeNull();
+            givenTargetObjWithIgnoredProperties.Age.Should().Be(expectedAge);
+            givenTargetObjWithIgnoredProperties.Birthdate.Should().Be(givenSourceObj.Birthdate);
+            givenTargetObjWithIgnoredProperties.IsJedi.Should().Be(givenSourceObj.IsJedi);
+        }
+
+        [TestCase]
         public void Mapper_Should_Map_Primitive_Type_Props_Without_Ignored_Props()
         {
             // given


### PR DESCRIPTION
`CopyPropertiesTo` object extension is updated. The new version uses dynamic methods (IL) to complete prop to prop copying operation. It should perform faster and it can copy props between different types of objects. Examples are included as a test file.

![Screen Shot 2021-10-25 at 8 30 27 AM](https://user-images.githubusercontent.com/26522493/138725712-fcab6d94-a8e8-479e-873b-cf5457ffe37d.png)
