### PR TITLE
feat: adds controller for undoing a delete operation on an entity

### DIFF
--- a/Firebend.AutoCrud.ChangeTracking.Web/Abstractions/AbstractChangeTrackingReadController.cs
+++ b/Firebend.AutoCrud.ChangeTracking.Web/Abstractions/AbstractChangeTrackingReadController.cs
@@ -73,9 +73,7 @@ namespace Firebend.AutoCrud.ChangeTracking.Web.Abstractions
             changeSearchRequest.CopyPropertiesTo(changeRequest);
             changeRequest.EntityId = key.Value;
 
-            var changes = await _read
-                .GetChangesByEntityId(changeRequest, cancellationToken)
-                .ConfigureAwait(false);
+            var changes = await _read.GetChangesByEntityId(changeRequest, cancellationToken);
 
             if (!(changes?.Data?.Any() ?? false))
             {

--- a/Firebend.AutoCrud.CustomFields.Web/Abstractions/AbstractCustomFieldsCreateController.cs
+++ b/Firebend.AutoCrud.CustomFields.Web/Abstractions/AbstractCustomFieldsCreateController.cs
@@ -63,9 +63,7 @@ public abstract class AbstractCustomFieldsCreateController<TKey, TEntity, TVersi
             return GetInvalidModelStateResult();
         }
 
-        var isValid = await _customFieldsValidationService
-            .ValidateAsync(entity, cancellationToken)
-            .ConfigureAwait(false);
+        var isValid = await _customFieldsValidationService.ValidateAsync(entity, cancellationToken);
 
         if (!isValid.WasSuccessful)
         {
@@ -82,8 +80,7 @@ public abstract class AbstractCustomFieldsCreateController<TKey, TEntity, TVersi
             entity = isValid.Model;
         }
 
-        var result = await _createService
-            .CreateAsync(rootKey.Value, entity, cancellationToken).ConfigureAwait(false);
+        var result = await _createService.CreateAsync(rootKey.Value, entity, cancellationToken);
 
         if (result == null)
         {

--- a/Firebend.AutoCrud.CustomFields.Web/Abstractions/AbstractCustomFieldsDeleteController.cs
+++ b/Firebend.AutoCrud.CustomFields.Web/Abstractions/AbstractCustomFieldsDeleteController.cs
@@ -54,9 +54,7 @@ namespace Firebend.AutoCrud.CustomFields.Web.Abstractions
                 return GetInvalidModelStateResult();
             }
 
-            var result = await _deleteService
-                .DeleteAsync(rootKey.Value, id, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await _deleteService.DeleteAsync(rootKey.Value, id, cancellationToken);
 
             if (result == null)
             {

--- a/Firebend.AutoCrud.CustomFields.Web/Abstractions/AbstractCustomFieldsSearchController.cs
+++ b/Firebend.AutoCrud.CustomFields.Web/Abstractions/AbstractCustomFieldsSearchController.cs
@@ -52,7 +52,7 @@ namespace Firebend.AutoCrud.CustomFields.Web.Abstractions
                 return GetInvalidModelStateResult();
             }
 
-            var result = await _searchService.SearchAsync(searchRequest,cancellationToken);
+            var result = await _searchService.SearchAsync(searchRequest, cancellationToken);
 
             return Ok(result);
         }

--- a/Firebend.AutoCrud.CustomFields.Web/Abstractions/AbstractCustomFieldsSearchController.cs
+++ b/Firebend.AutoCrud.CustomFields.Web/Abstractions/AbstractCustomFieldsSearchController.cs
@@ -52,10 +52,7 @@ namespace Firebend.AutoCrud.CustomFields.Web.Abstractions
                 return GetInvalidModelStateResult();
             }
 
-            var result = await _searchService.SearchAsync(
-                    searchRequest,
-                    cancellationToken)
-                .ConfigureAwait(false);
+            var result = await _searchService.SearchAsync(searchRequest,cancellationToken);
 
             return Ok(result);
         }

--- a/Firebend.AutoCrud.CustomFields.Web/Abstractions/AbstractCustomFieldsUpdateController.cs
+++ b/Firebend.AutoCrud.CustomFields.Web/Abstractions/AbstractCustomFieldsUpdateController.cs
@@ -94,9 +94,7 @@ namespace Firebend.AutoCrud.CustomFields.Web.Abstractions
                 entity = isValid.Model;
             }
 
-            var result = await _updateService
-                .UpdateAsync(rootKey.Value, entity, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await _updateService.UpdateAsync(rootKey.Value, entity, cancellationToken);
 
             if (result == null)
             {
@@ -150,9 +148,7 @@ namespace Firebend.AutoCrud.CustomFields.Web.Abstractions
                 return GetInvalidModelStateResult();
             }
 
-            var isValid = await _customFieldsValidationService
-                .ValidateAsync(entityPatchDocument, cancellationToken)
-                .ConfigureAwait(false);
+            var isValid = await _customFieldsValidationService.ValidateAsync(entityPatchDocument, cancellationToken);
 
             if (!isValid.WasSuccessful)
             {
@@ -169,9 +165,7 @@ namespace Firebend.AutoCrud.CustomFields.Web.Abstractions
                 entityPatchDocument = isValid.Model;
             }
 
-            var result = await _updateService
-                .PatchAsync(rootKey.Value, id, entityPatchDocument, cancellationToken)
-                .ConfigureAwait(false);
+            var result = await _updateService.PatchAsync(rootKey.Value, id, entityPatchDocument, cancellationToken);
 
             if (result == null)
             {

--- a/Firebend.AutoCrud.IntegrationTests/EfEndToEndTest.cs
+++ b/Firebend.AutoCrud.IntegrationTests/EfEndToEndTest.cs
@@ -31,9 +31,9 @@ public class EfEndToEndTest : BaseTest<
         await TestRunner.Authenticate();
         var nickName = Guid.NewGuid().ToString();
 
-        var personHeader = "FirstName,LastName,FullName,Id,CreatedDate,ModifiedDate";
-        var petHeader = "Id,EfPersonId,PetName,PetType,CreatedDate,ModifiedDate";
-        var customFieldHeader = "EntityId,Key,Value,Id,CreatedDate,ModifiedDate";
+        const string personHeader = "FirstName,LastName,FullName,Id,CreatedDate,ModifiedDate";
+        const string petHeader = "Id,EfPersonId,PetName,PetType,CreatedDate,ModifiedDate";
+        const string customFieldHeader = "EntityId,Key,Value,Id,CreatedDate,ModifiedDate";
 
         var exportResult = await GetExportAsync(nickName);
         exportResult.Should().NotContain(nickName);

--- a/Firebend.AutoCrud.IntegrationTests/Fakers/PetFaker.cs
+++ b/Firebend.AutoCrud.IntegrationTests/Fakers/PetFaker.cs
@@ -15,6 +15,7 @@ namespace Firebend.AutoCrud.IntegrationTests.Fakers
                     .StrictMode(true)
                     .RuleFor(x => x.PetName, f => f.Person.FirstName)
                     .RuleFor(x => x.PetType, f => f.Hacker.Verb())
+                    .RuleFor(x => x.IsDeleted, false)
                     .RuleFor(x => x.DataAuth, f => new DataAuth { UserEmails = new[] { f.Person.Email } });
 
                 return _fakerViewModelBase;

--- a/Firebend.AutoCrud.Io.Web/Abstractions/AbstractEntityExportControllerService.cs
+++ b/Firebend.AutoCrud.Io.Web/Abstractions/AbstractEntityExportControllerService.cs
@@ -49,15 +49,11 @@ namespace Firebend.AutoCrud.Io.Web.Abstractions
                 throw new ArgumentNullException(nameof(search));
             }
 
-            var entities = await _searchService
-                .SearchAsync(search, cancellationToken)
-                .ConfigureAwait(false);
+            var entities = await _searchService.SearchAsync(search, cancellationToken);
 
             var records = MapRecords(entities);
 
-            var fileStream = await _exportService
-                .ExportAsync(fileType, records, cancellationToken)
-                .ConfigureAwait(false);
+            var fileStream = await _exportService.ExportAsync(fileType, records, cancellationToken);
 
             var mimeType = _entityFileTypeMimeTypeMapper.MapMimeType(fileType);
             var extension = _entityFileTypeMimeTypeMapper.GetExtension(fileType);

--- a/Firebend.AutoCrud.Io.Web/Abstractions/AbstractIoController.cs
+++ b/Firebend.AutoCrud.Io.Web/Abstractions/AbstractIoController.cs
@@ -83,8 +83,7 @@ public abstract class AbstractIoController<TKey, TEntity, TVersion, TSearch, TMa
                 entityExportType.GetValueOrDefault(),
                 filename,
                 searchRequest,
-                cancellationToken)
-            .ConfigureAwait(false);
+                cancellationToken);
 
         return fileResult;
     }

--- a/Firebend.AutoCrud.Mongo/Abstractions/Client/MongoClientBase.cs
+++ b/Firebend.AutoCrud.Mongo/Abstractions/Client/MongoClientBase.cs
@@ -11,6 +11,8 @@ namespace Firebend.AutoCrud.Mongo.Abstractions.Client
     public static class MongoClientBaseDefaults
     {
 #pragma warning disable CA2211, IDE1006
+        // ReSharper disable once FieldCanBeMadeReadOnly.Global
+        // ReSharper disable once InconsistentNaming
         public static int NumberOfRetries = 7;
 #pragma warning restore CA2211, IDE1006
     }

--- a/Firebend.AutoCrud.Mongo/Implementations/MongoEntityTransaction.cs
+++ b/Firebend.AutoCrud.Mongo/Implementations/MongoEntityTransaction.cs
@@ -16,6 +16,8 @@ namespace Firebend.AutoCrud.Mongo.Implementations
     public static class MongoEntityTransactionsDefaults
     {
 #pragma warning disable CA2211, IDE1006
+        // ReSharper disable once FieldCanBeMadeReadOnly.Global
+        // ReSharper disable once InconsistentNaming
         public static int NumberOfRetries = 10;
 #pragma warning restore CA2211, IDE1006
     }

--- a/Firebend.AutoCrud.Mongo/Implementations/MongoEntityTransactionFactory.cs
+++ b/Firebend.AutoCrud.Mongo/Implementations/MongoEntityTransactionFactory.cs
@@ -13,7 +13,11 @@ namespace Firebend.AutoCrud.Mongo.Implementations
     public static class MongoEntityTransactionFactoryDefaults
     {
 #pragma warning disable CA2211, IDE1006
+        // ReSharper disable once InconsistentNaming
+        // ReSharper disable once FieldCanBeMadeReadOnly.Global
         public static TransactionOptions TransactionOptions;
+        // ReSharper disable once InconsistentNaming
+        // ReSharper disable once FieldCanBeMadeReadOnly.Global
         public static ClientSessionOptions SessionOptions;
 #pragma warning restore CA2211, IDE1006
 

--- a/Firebend.AutoCrud.Web.Sample/Extensions/SampleEntityExtensions.cs
+++ b/Firebend.AutoCrud.Web.Sample/Extensions/SampleEntityExtensions.cs
@@ -124,6 +124,7 @@ namespace Firebend.AutoCrud.Web.Sample.Extensions
                         CustomFieldValidationService<Guid, MongoTenantPerson, V1>>()
                 );
 
+        // ReSharper disable once UnusedMethodReturnValue.Local
         private static EntityCrudBuilder<Guid, MongoTenantPerson> AddMongoPersonApiV2(this EntityCrudBuilder<Guid, MongoTenantPerson> builder) =>
             builder
                 .AddIo<Guid, MongoTenantPerson, V2>(io => io.WithMapper(x => new PersonExport(x)))

--- a/Firebend.AutoCrud.Web.Sample/Models/CreatePersonViewModel.cs
+++ b/Firebend.AutoCrud.Web.Sample/Models/CreatePersonViewModel.cs
@@ -131,7 +131,7 @@ public class PersonViewModelBaseV2 : IEntityViewModelBase
     public DataAuth DataAuth { get; set; }
 }
 
-public class GetPersonViewModel : PersonViewModelBase, IEntityViewModelRead<Guid>, ICustomFieldsEntity<Guid>
+public class GetPersonViewModel : PersonViewModelBase, IEntityViewModelRead<Guid>, ICustomFieldsEntity<Guid>, IActiveEntity
 {
     private static readonly string[] Ignores = { nameof(CustomFields) };
     public List<CustomFieldsEntity<Guid>> CustomFields { get; set; }

--- a/Firebend.AutoCrud.Web.Sample/Models/PetViewModel.cs
+++ b/Firebend.AutoCrud.Web.Sample/Models/PetViewModel.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Firebend.AutoCrud.Web.Sample.Models
 {
-    public class PetBaseViewModel : IEntityViewModelBase
+    public class PetBaseViewModel : IEntityViewModelBase, IActiveEntity
     {
         [Required]
         [MaxLength(205)]
@@ -18,6 +18,7 @@ namespace Firebend.AutoCrud.Web.Sample.Models
         public string PetType { get; set; }
 
         public DataAuth DataAuth { get; set; }
+        public bool IsDeleted { get; set; }
     }
 
     public class CreatePetViewModel : IEntityViewModelCreate<PetBaseViewModel>

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractControllerWithKeyParser.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractControllerWithKeyParser.cs
@@ -70,5 +70,15 @@ namespace Firebend.AutoCrud.Web.Abstractions
 
             return false;
         }
+
+        protected bool HasIsDeletedChanged(object original, object toUpdate)
+        {
+            if (original is IActiveEntity originalActive && toUpdate is IActiveEntity toUpdateActive)
+            {
+                return originalActive.IsDeleted != toUpdateActive.IsDeleted;
+            }
+
+            return false;
+        }
     }
 }

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractControllerWithKeyParser.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractControllerWithKeyParser.cs
@@ -15,6 +15,9 @@ namespace Firebend.AutoCrud.Web.Abstractions
     {
         private readonly IEntityKeyParser<TKey, TEntity, TVersion> _keyParser;
 
+        private Type _entityType;
+        private Type EntityType => _entityType ??= typeof(TEntity);
+
         protected AbstractControllerWithKeyParser(IEntityKeyParser<TKey, TEntity, TVersion> keyParser,
             IOptions<ApiBehaviorOptions> apiOptions) : base(apiOptions)
         {
@@ -40,11 +43,13 @@ namespace Firebend.AutoCrud.Web.Abstractions
             return id;
         }
 
-        protected bool IsCustomFieldsEntity() => typeof(TEntity).IsAssignableToGenericType(typeof(ICustomFieldsEntity<>));
+        protected bool IsCustomFieldsEntity() => EntityType.IsAssignableToGenericType(typeof(ICustomFieldsEntity<>));
+
+        protected bool IsActiveEntity() => EntityType.IsAssignableTo(typeof(IActiveEntity));
 
         protected bool HasCustomFieldsPopulated(object o)
         {
-            var property = typeof(TEntity).GetProperty(nameof(ICustomFieldsEntity<Guid>.CustomFields));
+            var property = EntityType.GetProperty(nameof(ICustomFieldsEntity<Guid>.CustomFields));
 
             if (property == null)
             {
@@ -54,6 +59,16 @@ namespace Firebend.AutoCrud.Web.Abstractions
             var value = property.GetValue(o, null);
 
             return value != null;
+        }
+
+        protected bool HasIsDeletedPopulated(object o)
+        {
+            if (o is IActiveEntity activeEntity)
+            {
+                return activeEntity.IsDeleted;
+            }
+
+            return false;
         }
     }
 }

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityCreateController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityCreateController.cs
@@ -57,18 +57,14 @@ namespace Firebend.AutoCrud.Web.Abstractions
                 return GetInvalidModelStateResult();
             }
 
-            var entity = await _mapper
-                .FromAsync(body, cancellationToken)
-                .ConfigureAwait(false);
+            var entity = await _mapper.FromAsync(body, cancellationToken);
 
             if (!TryValidateModel(entity))
             {
                 return GetInvalidModelStateResult();
             }
 
-            var isValid = await _entityValidationService
-                .ValidateAsync(null, entity, null, cancellationToken)
-                .ConfigureAwait(false);
+            var isValid = await _entityValidationService.ValidateAsync(null, entity, null, cancellationToken);
 
             if (!isValid.WasSuccessful)
             {
@@ -89,9 +85,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
 
             try
             {
-                created = await _createService
-                    .CreateAsync(entity, cancellationToken)
-                    .ConfigureAwait(false);
+                created = await _createService.CreateAsync(entity, cancellationToken);
             }
             catch (AutoCrudEntityException ex)
             {
@@ -113,9 +107,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
 
             var read = await _readService.GetByKeyAsync(created.Id, cancellationToken);
 
-            var createdViewModel = await _readMapper
-                .ToAsync(read, cancellationToken)
-                .ConfigureAwait(false);
+            var createdViewModel = await _readMapper.ToAsync(read, cancellationToken);
 
             return Created($"{Request.Path.Value}/{created.Id}", createdViewModel);
         }

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityCreateMultipleController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityCreateMultipleController.cs
@@ -66,13 +66,9 @@ namespace Firebend.AutoCrud.Web.Abstractions
 
             foreach (var toCreate in body.Entities)
             {
-                var entityToCreate = await _multipleMapper
-                    .FromAsync(body, toCreate, cancellationToken)
-                    .ConfigureAwait(false);
+                var entityToCreate = await _multipleMapper.FromAsync(body, toCreate, cancellationToken);
 
-                var isValid = await _entityValidationService
-                    .ValidateAsync(null, entityToCreate, null, cancellationToken)
-                    .ConfigureAwait(false);
+                var isValid = await _entityValidationService.ValidateAsync(null, entityToCreate, null, cancellationToken);
 
                 if (!isValid.WasSuccessful)
                 {
@@ -107,9 +103,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
 
                 try
                 {
-                    entity = await _createService
-                        .CreateAsync(entityToCreate, cancellationToken)
-                        .ConfigureAwait(false);
+                    entity = await _createService.CreateAsync(entityToCreate, cancellationToken);
                 }
                 catch (AutoCrudEntityException ex)
                 {
@@ -131,9 +125,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
                     continue;
                 }
 
-                var mappedEntity = await _readMapper
-                    .ToAsync(entity, cancellationToken)
-                    .ConfigureAwait(false);
+                var mappedEntity = await _readMapper.ToAsync(entity, cancellationToken);
 
                 createdEntities.Add(mappedEntity);
             }

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityDeleteController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityDeleteController.cs
@@ -50,18 +50,14 @@ namespace Firebend.AutoCrud.Web.Abstractions
                 return GetInvalidModelStateResult();
             }
 
-            var deleted = await _deleteService
-                .DeleteAsync(key.Value, cancellationToken)
-                .ConfigureAwait(false);
+            var deleted = await _deleteService.DeleteAsync(key.Value, cancellationToken);
 
             if (deleted == null)
             {
                 return NotFound(new { id });
             }
 
-            var mapped = await _viewModelMapper
-                .ToAsync(deleted, cancellationToken)
-                .ConfigureAwait(false);
+            var mapped = await _viewModelMapper.ToAsync(deleted, cancellationToken);
 
             return Ok(mapped);
         }

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityReadAllController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityReadAllController.cs
@@ -39,18 +39,14 @@ namespace Firebend.AutoCrud.Web.Abstractions
         {
             Response.RegisterForDispose(_readService);
 
-            var entities = await _readService
-                .GetAllAsync(cancellationToken)
-                .ConfigureAwait(false);
+            var entities = await _readService.GetAllAsync(cancellationToken);
 
             if (entities == null || !entities.Any())
             {
                 return Ok();
             }
 
-            var mapped = await _viewModelMapper
-                .ToAsync(entities, cancellationToken)
-                .ConfigureAwait(false);
+            var mapped = await _viewModelMapper.ToAsync(entities, cancellationToken);
 
             return Ok(mapped);
         }

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityReadController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityReadController.cs
@@ -49,18 +49,14 @@ namespace Firebend.AutoCrud.Web.Abstractions
                 return GetInvalidModelStateResult();
             }
 
-            var entity = await _readService
-                .GetByKeyAsync(key.Value, cancellationToken)
-                .ConfigureAwait(false);
+            var entity = await _readService.GetByKeyAsync(key.Value, cancellationToken);
 
             if (entity == null)
             {
                 return NotFound(new { id });
             }
 
-            var mapped = await _viewModelMapper
-                .ToAsync(entity, cancellationToken)
-                .ConfigureAwait(false);
+            var mapped = await _viewModelMapper.ToAsync(entity, cancellationToken);
 
             return Ok(mapped);
         }

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntitySearchController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntitySearchController.cs
@@ -68,9 +68,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
 
             searchRequest.DoCount ??= true;
 
-            var entities = await _searchService
-                .PageAsync(searchRequest, cancellationToken)
-                .ConfigureAwait(false);
+            var entities = await _searchService.PageAsync(searchRequest, cancellationToken);
 
             if (!(entities?.Data?.Any() ?? false))
             {

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityUndoDeleteController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityUndoDeleteController.cs
@@ -1,0 +1,81 @@
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using Firebend.AutoCrud.Core.Interfaces;
+using Firebend.AutoCrud.Core.Interfaces.Models;
+using Firebend.AutoCrud.Core.Interfaces.Services.Entities;
+using Firebend.AutoCrud.Web.Interfaces;
+using Microsoft.AspNetCore.JsonPatch;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Firebend.AutoCrud.Web.Abstractions
+{
+    [ApiController]
+    public abstract class AbstractEntityUndoDeleteController<TKey, TEntity, TVersion, TViewModel> : AbstractControllerWithKeyParser<TKey, TEntity, TVersion>
+        where TKey : struct
+        where TEntity : class, IEntity<TKey>, IActiveEntity
+        where TVersion : class, IAutoCrudApiVersion
+        where TViewModel : class
+    {
+        private readonly IEntityUpdateService<TKey, TEntity> _updateService;
+        private readonly IEntityReadService<TKey, TEntity> _readService;
+        private readonly IReadViewModelMapper<TKey, TEntity, TVersion, TViewModel> _viewModelMapper;
+
+        protected AbstractEntityUndoDeleteController(IEntityUpdateService<TKey, TEntity> updateService,
+            IEntityKeyParser<TKey, TEntity, TVersion> entityKeyParser,
+            IReadViewModelMapper<TKey, TEntity, TVersion, TViewModel> viewModelMapper,
+            IOptions<ApiBehaviorOptions> apiOptions,
+            IEntityReadService<TKey, TEntity> readService) : base(entityKeyParser, apiOptions)
+        {
+            _updateService = updateService;
+            _viewModelMapper = viewModelMapper;
+            _readService = readService;
+        }
+
+        [HttpPost("{id}/undo-delete")]
+        [SwaggerOperation("Undoes a delete for a given {entityName}.")]
+        [SwaggerResponse(200, "A {entityName} with the given key is not longer deleted.")]
+        [SwaggerResponse(400, "The request is invalid.", typeof(ValidationProblemDetails))]
+        [SwaggerResponse(403, "Forbidden")]
+        [SwaggerResponse(404, "The {entityName} with the given key is not found.")]
+        [Produces("application/json")]
+        public virtual async Task<ActionResult<TViewModel>> UndoDeleteAsync(
+            [Required][FromRoute] string id,
+            CancellationToken cancellationToken)
+        {
+            Response.RegisterForDispose(_updateService);
+
+            var key = GetKey(id);
+
+            if (!key.HasValue)
+            {
+                return GetInvalidModelStateResult();
+            }
+
+            var entity = await _readService.GetByKeyAsync(key.Value, cancellationToken);
+
+            if (entity is null)
+            {
+                return NotFound(new { id });
+            }
+
+            var patch = new JsonPatchDocument<TEntity>();
+            patch.Replace(x => x.IsDeleted, false);
+
+            var deleted = await _updateService.PatchAsync(key.Value, patch, cancellationToken);
+
+            if (deleted == null)
+            {
+                return NotFound(new { id });
+            }
+
+            entity.IsDeleted = false;
+
+            var mapped = await _viewModelMapper.ToAsync(entity, cancellationToken);
+
+            return Ok(mapped);
+        }
+    }
+}

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityUpdateController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityUpdateController.cs
@@ -111,6 +111,14 @@ namespace Firebend.AutoCrud.Web.Abstractions
 
             var original = await _readService.GetByKeyAsync(key.Value, cancellationToken);
 
+            if (HasIsDeletedChanged(original, entityUpdate))
+            {
+                ModelState.AddModelError(nameof(body),
+                    $"Modifying an entity's {nameof(IActiveEntity.IsDeleted)} is not allowed in this endpoint.");
+
+                return GetInvalidModelStateResult();
+            }
+
             var patch = original is null
                 ? null
                 : _jsonPatchGenerator.Generate(original, entityUpdate);

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityUpdateController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityUpdateController.cs
@@ -20,7 +20,6 @@ using Swashbuckle.AspNetCore.Annotations;
 namespace Firebend.AutoCrud.Web.Abstractions
 {
     [ApiController]
-    [Route("{id}")]
     public abstract class
         AbstractEntityUpdateController<TKey, TEntity, TVersion, TUpdateViewModel, TUpdateViewModelBody, TReadViewModel> :
             AbstractControllerWithKeyParser<TKey, TEntity, TVersion>
@@ -62,7 +61,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
             _copyOnPatchPropertyAccessor = copyOnPatchPropertyAccessor;
         }
 
-        [HttpPut]
+        [HttpPut("{id}")]
         [SwaggerOperation("Updates {entityNamePlural}")]
         [SwaggerResponse(200, "The {entityName} with a given key was updated.")]
         [SwaggerResponse(400, "The request is invalid.", typeof(ValidationProblemDetails))]
@@ -174,7 +173,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
             return Ok(mapped);
         }
 
-        [HttpPatch]
+        [HttpPatch("{id}")]
         [SwaggerOperation("Updates {entityNamePlural} using a JSON Patch Document")]
         [SwaggerResponse(200, "The {entityName} with the given key was updated.")]
         [SwaggerResponse(400, "The request is invalid.", typeof(ValidationProblemDetails))]

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityValidateCreateController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityValidateCreateController.cs
@@ -47,9 +47,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
                 return GetInvalidModelStateResult();
             }
 
-            var createdViewModel = await _readMapper
-                .ToAsync(entity, cancellationToken)
-                .ConfigureAwait(false);
+            var createdViewModel = await _readMapper.ToAsync(entity, cancellationToken);
 
             _mapper = null;
             _readMapper = null;

--- a/Firebend.AutoCrud.Web/Abstractions/AbstractEntityValidateUpdateController.cs
+++ b/Firebend.AutoCrud.Web/Abstractions/AbstractEntityValidateUpdateController.cs
@@ -68,9 +68,7 @@ namespace Firebend.AutoCrud.Web.Abstractions
 
             entityUpdate.Id = key.Value;
 
-            var mapped = await _readViewModelMapper
-                .ToAsync(entityUpdate, cancellationToken)
-                .ConfigureAwait(false);
+            var mapped = await _readViewModelMapper.ToAsync(entityUpdate, cancellationToken);
 
             return Ok(mapped);
         }

--- a/Firebend.AutoCrud.Web/ControllerConfigurator.AuthorizationPolicies.cs
+++ b/Firebend.AutoCrud.Web/ControllerConfigurator.AuthorizationPolicies.cs
@@ -112,7 +112,8 @@ public partial class ControllerConfigurator<TBuilder, TKey, TEntity, TVersion>
     /// </code>
     /// </example>
     public ControllerConfigurator<TBuilder, TKey, TEntity, TVersion> AddDeleteAuthorizationPolicy(string policy)
-        => AddAuthorizationPolicy(DeleteControllerType(), policy);
+        => AddAuthorizationPolicy(DeleteControllerType(), policy)
+            .AddAuthorizationPolicy(UndoDeleteControllerType(), policy);
 
     /// <summary>
     /// Adds an authorization policy to GET requests using the abstract read controller

--- a/Firebend.AutoCrud.Web/ControllerConfigurator.ResourceAuthorization.cs
+++ b/Firebend.AutoCrud.Web/ControllerConfigurator.ResourceAuthorization.cs
@@ -65,7 +65,9 @@ public partial class ControllerConfigurator<TBuilder, TKey, TEntity, TVersion>
     public ControllerConfigurator<TBuilder, TKey, TEntity, TVersion> AddDeleteResourceAuthorization(
         string policy = DeleteAuthorizationRequirement.DefaultPolicy)
         => this.AddResourceAuthorization(DeleteControllerType(),
-            typeof(EntityDeleteAuthorizationFilter<TKey, TEntity, TVersion>), policy);
+            typeof(EntityDeleteAuthorizationFilter<TKey, TEntity, TVersion>), policy)
+            .AddResourceAuthorization(UndoDeleteControllerType(),
+                typeof(EntityDeleteAuthorizationFilter<TKey, TEntity, TVersion>), policy);
 
     /// <summary>
     /// Adds resource authorization to GET requests using the abstract read controller

--- a/Firebend.AutoCrud.Web/ControllerConfigurator.cs
+++ b/Firebend.AutoCrud.Web/ControllerConfigurator.cs
@@ -88,7 +88,7 @@ public partial class
         return (routeType, attributeBuilder);
     }
 
-    private (Type attributeType, CustomAttributeBuilder attributeBuilder) GetApiVersionAttributeInfo(bool deprecated)
+    private static (Type attributeType, CustomAttributeBuilder attributeBuilder) GetApiVersionAttributeInfo(bool deprecated)
     {
         var type = typeof(ApiVersionAttribute);
         var ctor = type.GetConstructor(new[] { typeof(string) });
@@ -99,6 +99,11 @@ public partial class
         }
 
         var version = (IAutoCrudApiVersion)Activator.CreateInstance(typeof(TVersion));
+
+        if (version is null)
+        {
+            return (null, null);
+        }
 
         var propertyInfos = type.GetProperties().Where(x => x.Name == nameof(ApiVersionAttribute.Deprecated)).Take(1).ToArray();
 
@@ -152,7 +157,7 @@ public partial class
         string openApiName = null,
         params Type[] genericArgs)
     {
-        var hasGenerics = genericArgs != null && genericArgs.Length > 0;
+        var hasGenerics = genericArgs is { Length: > 0 };
         var registrationType = hasGenerics ? type.MakeGenericType(genericArgs) : type;
 
         var typeToCheckGeneric = hasGenerics ? typeToCheck.MakeGenericType(genericArgs) : typeToCheck;
@@ -286,7 +291,11 @@ public partial class
         AddAttributeToAllControllers(routeType, routeBuilder);
 
         var (apiVersionType, apiVersionBuilder) = GetApiVersionAttributeInfo(deprecated);
-        AddAttributeToAllControllers(apiVersionType, apiVersionBuilder);
+
+        if (apiVersionType is not null && apiVersionBuilder is not null)
+        {
+            AddAttributeToAllControllers(apiVersionType, apiVersionBuilder);
+        }
 
         return this;
     }
@@ -369,6 +378,10 @@ public partial class
     public Type SearchControllerType()
         => typeof(AbstractEntitySearchController<,,,,,>)
             .MakeGenericType(Builder.EntityKeyType, Builder.EntityType, typeof(TVersion), Builder.SearchRequestType, SearchViewModelType, ReadViewModelType);
+
+    public Type UndoDeleteControllerType()
+        => typeof(AbstractEntityUndoDeleteController<,,,>)
+            .MakeGenericType(Builder.EntityKeyType, Builder.EntityType, typeof(TVersion), ReadViewModelType);
 
     /// <summary>
     /// Registers a CREATE controller for the entity
@@ -1009,8 +1022,11 @@ public partial class
     ///          .WithAllControllers(true, true)
     /// </code>
     /// </example>
-    public ControllerConfigurator<TBuilder, TKey, TEntity, TVersion> WithAllControllers(bool includeGetAll = false,
-        bool includeMultipleCreate = true, bool includeValidationController = true)
+    public ControllerConfigurator<TBuilder, TKey, TEntity, TVersion> WithAllControllers(
+        bool includeGetAll = false,
+        bool includeMultipleCreate = true,
+        bool includeValidationController = true,
+        bool includeUndoDeleteControllerIfActiveEntity = true)
     {
         WithReadController();
         WithCreateController(includeValidationController);
@@ -1026,6 +1042,11 @@ public partial class
         if (includeMultipleCreate)
         {
             WithCreateMultipleController();
+        }
+
+        if (includeUndoDeleteControllerIfActiveEntity && Builder.IsActiveEntity)
+        {
+            WithUndoDeleteController();
         }
 
         return this;
@@ -1083,4 +1104,64 @@ public partial class
 
         return this;
     }
+
+     /// <summary>
+    /// Registers a POST controller that will undo a soft delete for a given entity
+    /// </summary>
+    /// <param name="registrationType"></param>
+    /// <param name="viewModelMapper"></param>
+    /// <param name="makeRegistrationTypeGeneric"></param>
+    /// <example>
+    /// <code>
+    /// forecast.WithDefaultDatabase("Samples")
+    ///      .WithCollection("WeatherForecasts")
+    ///      .WithFullTextSearch()
+    ///      .AddCrud()
+    ///      .AddControllers(controllers => controllers
+    ///          .WithUndoDeleteController()
+    /// </code>
+    /// </example>
+    public ControllerConfigurator<TBuilder, TKey, TEntity, TVersion> WithUndoDeleteController(Type registrationType,
+        Type viewModelMapper = null,
+        bool makeRegistrationTypeGeneric = false) => WithControllerHelper(
+        typeof(AbstractEntityUndoDeleteController<,,,>),
+        typeof(IReadViewModelMapper<,,,>),
+        registrationType,
+        ReadViewModelType,
+        viewModelMapper,
+        makeRegistrationTypeGeneric);
+
+    /// <summary>
+    /// Registers a POST controller that will undo a soft delete for a given entity
+    /// </summary>
+    /// <typeparam name="TRegistrationType">The service type to use</typeparam>
+    /// <example>
+    /// <code>
+    /// forecast.WithDefaultDatabase("Samples")
+    ///      .WithCollection("WeatherForecasts")
+    ///      .WithFullTextSearch()
+    ///      .AddCrud()
+    ///      .AddControllers(controllers => controllers
+    ///          .WithUndoDeleteController<>()
+    /// </code>
+    /// </example>
+    public ControllerConfigurator<TBuilder, TKey, TEntity, TVersion> WithUndoDeleteController<TRegistrationType>()
+        => WithUndoDeleteController(typeof(TRegistrationType));
+
+    /// <summary>
+    /// Registers a POST controller that will undo a soft delete for a given entity
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// forecast.WithDefaultDatabase("Samples")
+    ///      .WithCollection("WeatherForecasts")
+    ///      .WithFullTextSearch()
+    ///      .AddCrud()
+    ///      .AddControllers(controllers => controllers
+    ///          .WithUndoDeleteController()
+    /// </code>
+    /// </example>
+    public ControllerConfigurator<TBuilder, TKey, TEntity, TVersion> WithUndoDeleteController()
+        => WithUndoDeleteController(typeof(AbstractEntityUndoDeleteController<,,,>),
+            makeRegistrationTypeGeneric: true);
 }

--- a/Firebend.AutoCrud.Web/ControllerConfigurator.cs
+++ b/Firebend.AutoCrud.Web/ControllerConfigurator.cs
@@ -1105,7 +1105,7 @@ public partial class
         return this;
     }
 
-     /// <summary>
+    /// <summary>
     /// Registers a POST controller that will undo a soft delete for a given entity
     /// </summary>
     /// <param name="registrationType"></param>

--- a/Firebend.AutoCrud.Web/ControllerExtensions.cs
+++ b/Firebend.AutoCrud.Web/ControllerExtensions.cs
@@ -26,9 +26,7 @@ public static class ControllerExtensions
             return null;
         }
 
-        var entity = await mapper
-            .FromAsync(body, cancellationToken)
-            .ConfigureAwait(false);
+        var entity = await mapper.FromAsync(body, cancellationToken);
 
         if (entity == null)
         {


### PR DESCRIPTION
- Removes `.ConfigureAwait(false)` from controllers
- Adds a new controller to undo a delete operation against a soft delete entity
- Adds validation to `PUT` and `PATCH` controllers to disallow altering the `IsDeleted` flag when the entity implements `IActiveEntity`
- Integration Test Results: 
![image](https://github.com/firebend/auto-crud/assets/10537213/70d94dff-1d87-4491-bda8-3a10c13f8551)
