### PR TITLE
fix: ensure change tracking db context provider accounts for multi-tenancy and Mongo Client caching

### DIFF
--- a/Firebend.AutoCrud.ChangeTracking.EntityFramework/Implementations/ChangeTrackingDbContextProvider.cs
+++ b/Firebend.AutoCrud.ChangeTracking.EntityFramework/Implementations/ChangeTrackingDbContextProvider.cs
@@ -68,7 +68,7 @@ public class ChangeTrackingDbContextProvider<TEntityKey, TEntity> :
         var changeTrackingType = typeof(ChangeTrackingEntity<TEntityKey, TEntity>);
         var type = scaffoldCacheContext.DbContext.Model.FindEntityType(changeTrackingType);
 
-        if(type is null)
+        if (type is null)
         {
             scaffoldCacheContext.Logger.LogWarning("Could not find entity type for {TypeName}", changeTrackingType.FullName);
             return false;

--- a/Firebend.AutoCrud.ChangeTracking.EntityFramework/Implementations/ChangeTrackingDbContextProvider.cs
+++ b/Firebend.AutoCrud.ChangeTracking.EntityFramework/Implementations/ChangeTrackingDbContextProvider.cs
@@ -12,6 +12,7 @@ using Firebend.AutoCrud.EntityFramework.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
 
 namespace Firebend.AutoCrud.ChangeTracking.EntityFramework.Implementations;
 
@@ -21,20 +22,25 @@ public class ChangeTrackingDbContextProvider<TEntityKey, TEntity> :
     where TEntity : class, IEntity<TEntityKey>
     where TEntityKey : struct
 {
+    private record ScaffoldCacheContext(DbContext DbContext, ILogger Logger);
+
     private readonly IDbContextConnectionStringProvider<TEntityKey, TEntity> _rootConnectionStringProvider;
+    private readonly ILogger<ChangeTrackingDbContextProvider<TEntityKey, TEntity>> _logger;
 
     public ChangeTrackingDbContextProvider(
         IDbContextFactory<ChangeTrackingDbContext<TEntityKey, TEntity>> contextFactory,
+        ILogger<ChangeTrackingDbContextProvider<TEntityKey, TEntity>> logger,
         IDbContextConnectionStringProvider<TEntityKey, TEntity> connectionStringProvider = null) :
         base(contextFactory)
     {
+        _logger = logger;
         _rootConnectionStringProvider = connectionStringProvider;
     }
 
     protected override void InitDb(DbContext dbContext)
     {
         base.InitDb(dbContext);
-        ScaffoldDbContext(dbContext);
+        ScaffoldDbContext(dbContext, _logger);
     }
 
     protected override async Task<string> ProvideConnectionString(CancellationToken cancellationToken)
@@ -47,32 +53,52 @@ public class ChangeTrackingDbContextProvider<TEntityKey, TEntity> :
         return await _rootConnectionStringProvider.GetConnectionStringAsync(cancellationToken);
     }
 
-    private static void ScaffoldDbContext(DbContext context)
-        => ChangeTrackingDbContextProviderCache.ScaffoldCache.GetOrAdd(typeof(TEntity).FullName,
-            ScaffoldCacheFactory,
-            context);
-
-    private static bool ScaffoldCacheFactory(string typeName, DbContext dbContext)
+    private static void ScaffoldDbContext(DbContext context, ILogger logger)
     {
-        var type = dbContext.Model.FindEntityType(typeof(ChangeTrackingEntity<TEntityKey, TEntity>))
-                   ?? throw new Exception("Could not find entity type.");
+        var dbConn = context.Database.GetDbConnection();
+        var cacheKey = $"{dbConn.DataSource}_{dbConn.Database}_{typeof(TEntity).FullName}";
 
-        var schema = type.GetSchema().Coalesce("dbo");
-        var table = type.GetTableName();
+        ChangeTrackingDbContextProviderCache.ScaffoldCache.GetOrAdd(cacheKey,
+            ScaffoldCacheFactory,
+            new ScaffoldCacheContext(context, logger));
+    }
 
-        if (dbContext.Database.GetService<IDatabaseCreator>() is not RelationalDatabaseCreator dbCreator)
+    private static bool ScaffoldCacheFactory(string typeName, ScaffoldCacheContext scaffoldCacheContext)
+    {
+        var changeTrackingType = typeof(ChangeTrackingEntity<TEntityKey, TEntity>);
+        var type = scaffoldCacheContext.DbContext.Model.FindEntityType(changeTrackingType);
+
+        if(type is null)
         {
+            scaffoldCacheContext.Logger.LogWarning("Could not find entity type for {TypeName}", changeTrackingType.FullName);
+            return false;
+        }
+
+        try
+        {
+
+            var schema = type.GetSchema().Coalesce("dbo");
+            var table = type.GetTableName();
+
+            if (scaffoldCacheContext.DbContext.Database.GetService<IDatabaseCreator>() is not RelationalDatabaseCreator dbCreator)
+            {
+                return true;
+            }
+
+            var exists = DoesTableExist(scaffoldCacheContext.DbContext, schema, table);
+
+            if (!exists)
+            {
+                dbCreator.CreateTables();
+            }
+
             return true;
         }
-
-        var exists = DoesTableExist(dbContext, schema, table);
-
-        if (!exists)
+        catch (Exception ex)
         {
-            dbCreator.CreateTables();
+            scaffoldCacheContext.Logger.LogError(ex, "Error scaffolding change tracking table for {TypeName}", changeTrackingType.FullName);
+            return true;
         }
-
-        return true;
     }
 
     private static bool DoesTableExist(DbContext context, string schemaName, string tableName)
@@ -87,7 +113,6 @@ public class ChangeTrackingDbContextProvider<TEntityKey, TEntity> :
         using var command = conn.CreateCommand();
 
         command.CommandText = $"""
-
                                    SELECT 1 FROM sys.tables AS T
                                        INNER JOIN sys.schemas AS S ON T.schema_id = S.schema_id
                                    WHERE S.Name = '{schemaName}' AND T.Name = '{tableName}'

--- a/Firebend.AutoCrud.ChangeTracking/Firebend.AutoCrud.ChangeTracking.csproj
+++ b/Firebend.AutoCrud.ChangeTracking/Firebend.AutoCrud.ChangeTracking.csproj
@@ -23,7 +23,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.2" />
+      <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Core/Firebend.AutoCrud.Core.csproj
+++ b/Firebend.AutoCrud.Core/Firebend.AutoCrud.Core.csproj
@@ -26,8 +26,8 @@
       <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
       <PackageReference Include="Firebend.JsonPatchGenerator" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
       <PackageReference Include="System.ComponentModel.Annotations" Version="6.0.0-preview.4.21253.7" />
       <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />

--- a/Firebend.AutoCrud.Core/Firebend.AutoCrud.Core.csproj
+++ b/Firebend.AutoCrud.Core/Firebend.AutoCrud.Core.csproj
@@ -24,7 +24,7 @@
 
     <ItemGroup>
       <PackageReference Include="AsyncKeyedLock" Version="6.3.4" />
-      <PackageReference Include="Firebend.JsonPatchGenerator" Version="8.0.1" />
+      <PackageReference Include="Firebend.JsonPatchGenerator" Version="8.0.3" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />

--- a/Firebend.AutoCrud.CustomFields.EntityFramework/Firebend.AutoCrud.CustomFields.EntityFramework.csproj
+++ b/Firebend.AutoCrud.CustomFields.EntityFramework/Firebend.AutoCrud.CustomFields.EntityFramework.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
     </ItemGroup>
 
 </Project>

--- a/Firebend.AutoCrud.CustomFields.Mongo/Implementations/MongoCustomFieldsUpdateService.cs
+++ b/Firebend.AutoCrud.CustomFields.Mongo/Implementations/MongoCustomFieldsUpdateService.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.JsonPatch.Operations;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 
 namespace Firebend.AutoCrud.CustomFields.Mongo.Implementations;
 
@@ -71,7 +72,7 @@ public class MongoCustomFieldsUpdateService<TKey, TEntity> :
                                 & Builders<TEntity>.Filter.ElemMatch(x => x.CustomFields, cf => cf.Id == customField.Id);
 
         var mongoCollection = await GetCollectionAsync();
-        var updateDefinition = Builders<TEntity>.Update.Set(x => x.CustomFields[-1], customField);
+        var updateDefinition = Builders<TEntity>.Update.Set(x => x.CustomFields.FirstMatchingElement(), customField);
 
         if (typeof(IModifiedEntity).IsAssignableFrom(typeof(TEntity)))
         {

--- a/Firebend.AutoCrud.DomainEvents.MassTransit/Firebend.AutoCrud.DomainEvents.MassTransit.csproj
+++ b/Firebend.AutoCrud.DomainEvents.MassTransit/Firebend.AutoCrud.DomainEvents.MassTransit.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="MassTransit" Version="8.1.3" />
+      <PackageReference Include="MassTransit" Version="8.2.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 

--- a/Firebend.AutoCrud.EntityFramework.Elastic/Firebend.AutoCrud.EntityFramework.Elastic.csproj
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/Firebend.AutoCrud.EntityFramework.Elastic.csproj
@@ -24,7 +24,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Azure.SqlDatabase.ElasticScale.Client" Version="2.4.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.EntityFramework.Sample/Firebend.AutoCrud.EntityFramework.Sample.csproj
+++ b/Firebend.AutoCrud.EntityFramework.Sample/Firebend.AutoCrud.EntityFramework.Sample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     </ItemGroup>

--- a/Firebend.AutoCrud.EntityFramework/Firebend.AutoCrud.EntityFramework.csproj
+++ b/Firebend.AutoCrud.EntityFramework/Firebend.AutoCrud.EntityFramework.csproj
@@ -23,9 +23,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.2" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.3" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     </ItemGroup>
 

--- a/Firebend.AutoCrud.IntegrationTests/BaseTest.cs
+++ b/Firebend.AutoCrud.IntegrationTests/BaseTest.cs
@@ -191,6 +191,8 @@ public abstract class BaseTest<
         var response = await Url.WithAuth()
             .SetQueryParam("pagenumber", 1)
             .SetQueryParam("pageSize", 10)
+            .SetQueryParam("isDeleted", "false")
+            .SetQueryParam("orderBy", "createdDate:desc")
             .SetQueryParam("doCount", true)
             .GetAsync();
 

--- a/Firebend.AutoCrud.IntegrationTests/Firebend.AutoCrud.IntegrationTests.csproj
+++ b/Firebend.AutoCrud.IntegrationTests/Firebend.AutoCrud.IntegrationTests.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="35.4.0" />
-        <PackageReference Include="CsvHelper" Version="31.0.0" />
+        <PackageReference Include="Bogus" Version="35.5.0" />
+        <PackageReference Include="CsvHelper" Version="31.0.3" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Flurl.Http" Version="4.0.2" />
         <PackageReference Include="Flurl.Http.Newtonsoft" Version="0.9.1" />
@@ -16,11 +16,11 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.2.1" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.2.1" />
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Firebend.AutoCrud.Io/Firebend.AutoCrud.Io.csproj
+++ b/Firebend.AutoCrud.Io/Firebend.AutoCrud.Io.csproj
@@ -24,7 +24,7 @@
 
     <ItemGroup>
       <PackageReference Include="ClosedXML" Version="0.102.2" />
-      <PackageReference Include="CsvHelper" Version="31.0.0" />
+      <PackageReference Include="CsvHelper" Version="31.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Mongo/Client/MongoClientFactory.cs
+++ b/Firebend.AutoCrud.Mongo/Client/MongoClientFactory.cs
@@ -13,16 +13,22 @@ public class MongoClientFactory<TKey, TEntity> : IMongoClientFactory<TKey, TEnti
     where TKey : struct
     where TEntity : class, IEntity<TKey>
 {
-    private record MongoClientCacheFactoryContext(ILogger Logger, MongoClientSettings Settings, bool EnableLogging);
+    private record MongoClientCacheFactoryContext(ILogger Logger,
+        MongoClientSettings Settings,
+        bool EnableLogging,
+        IMongoClientSettingsConfigurator SettingsConfigurator);
 
     private readonly ILogger _logger;
     private readonly IMongoConnectionStringProvider<TKey, TEntity> _connectionStringProvider;
+    private readonly IMongoClientSettingsConfigurator _settingsConfigurator;
 
     public MongoClientFactory(ILogger<MongoClientFactory<TKey, TEntity>> logger,
-        IMongoConnectionStringProvider<TKey, TEntity> connectionStringProvider)
+        IMongoConnectionStringProvider<TKey, TEntity> connectionStringProvider,
+        IMongoClientSettingsConfigurator settingsConfigurator = null)
     {
         _logger = logger;
         _connectionStringProvider = connectionStringProvider;
+        _settingsConfigurator = settingsConfigurator;
     }
 
     public async Task<IMongoClient> CreateClientAsync(string overrideShardKey = null, bool enableLogging = false)
@@ -34,7 +40,7 @@ public class MongoClientFactory<TKey, TEntity> : IMongoClientFactory<TKey, TEnti
         var client = MongoClientFactoryCache.MongoClients.GetOrAdd(
             mongoClientSettings.Server.ToString(),
             CreateClientForCache,
-            new MongoClientCacheFactoryContext(_logger, mongoClientSettings, enableLogging)
+            new MongoClientCacheFactoryContext(_logger, mongoClientSettings, enableLogging, _settingsConfigurator)
         );
 
         return client;
@@ -56,7 +62,11 @@ public class MongoClientFactory<TKey, TEntity> : IMongoClientFactory<TKey, TEnti
             context.Settings.ClusterConfigurator = cb => Configurator(cb, context);
         }
 
-        return new MongoClient(context.Settings);
+        var settings = context.SettingsConfigurator is null
+            ? context.Settings
+            : context.SettingsConfigurator.Configure(server, context.Settings);
+
+        return new MongoClient(settings);
     }
 
     private static void Configurator(ClusterBuilder cb, MongoClientCacheFactoryContext context)

--- a/Firebend.AutoCrud.Mongo/Client/MongoClientFactory.cs
+++ b/Firebend.AutoCrud.Mongo/Client/MongoClientFactory.cs
@@ -48,14 +48,7 @@ public class MongoClientFactory<TKey, TEntity> : IMongoClientFactory<TKey, TEnti
 
     private static IMongoClient CreateClientForCache(string server, MongoClientCacheFactoryContext context)
     {
-        //********************************************
-        // Author: JMA
-        // Date: 2023-03-27 02:04:09
-        // Comment: Mongo is planning on a version three of their driver.
-        // When using the V3 of the linq provider there are issues with having expressions that use
-        // object. For example: the AbstractEntitySearchService's GetSearchExpression function
-        //*******************************************
-        context.Settings.LinqProvider = LinqProvider.V2;
+        context.Settings.LinqProvider = LinqProvider.V3;
 
         if (context.EnableLogging)
         {

--- a/Firebend.AutoCrud.Mongo/Configuration/MongoDbConfigurator.cs
+++ b/Firebend.AutoCrud.Mongo/Configuration/MongoDbConfigurator.cs
@@ -51,7 +51,7 @@ public class MongoDbConfigurator : IMongoDbConfigurator
                     if (typeof(IEntity<>).IsAssignableFrom(map.ClassType))
                     {
                         map.MapIdProperty(mongoEntityIdName)
-                            .SetIdGenerator(MongoIdGeneratorComb.Instance)
+                            .SetIdGenerator(new MongoIdGeneratorComb())
                             .SetSerializer(new GuidSerializer(BsonType.String));
 
                         map.SetIgnoreExtraElements(true);

--- a/Firebend.AutoCrud.Mongo/Configuration/MongoIdGeneratorComb.cs
+++ b/Firebend.AutoCrud.Mongo/Configuration/MongoIdGeneratorComb.cs
@@ -6,8 +6,6 @@ namespace Firebend.AutoCrud.Mongo.Configuration;
 
 public class MongoIdGeneratorComb : IIdGenerator
 {
-    public static readonly MongoIdGeneratorComb Instance = new();
-
     public object GenerateId(object container, object document)
         => CombGuid.New();
 

--- a/Firebend.AutoCrud.Mongo/Firebend.AutoCrud.Mongo.csproj
+++ b/Firebend.AutoCrud.Mongo/Firebend.AutoCrud.Mongo.csproj
@@ -24,8 +24,8 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-      <PackageReference Include="MongoDB.Driver" Version="2.23.1" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+      <PackageReference Include="MongoDB.Driver" Version="2.24.0" />
       <PackageReference Include="Scrutor" Version="4.2.2" />
     </ItemGroup>
 

--- a/Firebend.AutoCrud.Mongo/Implementations/CombGuidMongoCollectionKeyGenerator.cs
+++ b/Firebend.AutoCrud.Mongo/Implementations/CombGuidMongoCollectionKeyGenerator.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Firebend.AutoCrud.Core.Ids;
 using Firebend.AutoCrud.Core.Interfaces.Models;
-using Firebend.AutoCrud.Mongo.Configuration;
 using Firebend.AutoCrud.Mongo.Interfaces;
 
 namespace Firebend.AutoCrud.Mongo.Implementations;
@@ -10,6 +10,6 @@ namespace Firebend.AutoCrud.Mongo.Implementations;
 public class CombGuidMongoCollectionKeyGenerator<TEntity> : IMongoCollectionKeyGenerator<Guid, TEntity>
     where TEntity : IEntity<Guid>
 {
-    public Task<Guid> GenerateKeyAsync(CancellationToken cancellationToken = default) =>
-        Task.FromResult((Guid)MongoIdGeneratorComb.Instance.GenerateId(Guid.NewGuid(), DateTime.UtcNow));
+    public Task<Guid> GenerateKeyAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(CombGuid.New());
 }

--- a/Firebend.AutoCrud.Mongo/Interfaces/IMongoClientSettingsConfigurator.cs
+++ b/Firebend.AutoCrud.Mongo/Interfaces/IMongoClientSettingsConfigurator.cs
@@ -1,0 +1,8 @@
+using MongoDB.Driver;
+
+namespace Firebend.AutoCrud.Mongo.Interfaces;
+
+public interface IMongoClientSettingsConfigurator
+{
+    MongoClientSettings Configure(string server, MongoClientSettings settings);
+}

--- a/Firebend.AutoCrud.Mongo/MongoClientFactoryCache.cs
+++ b/Firebend.AutoCrud.Mongo/MongoClientFactoryCache.cs
@@ -1,0 +1,9 @@
+using System.Collections.Concurrent;
+using MongoDB.Driver;
+
+namespace Firebend.AutoCrud.Mongo;
+
+public static class MongoClientFactoryCache
+{
+    public static readonly ConcurrentDictionary<string, IMongoClient> MongoClients = new();
+}

--- a/Firebend.AutoCrud.Tests/Firebend.AutoCrud.Tests.csproj
+++ b/Firebend.AutoCrud.Tests/Firebend.AutoCrud.Tests.csproj
@@ -16,9 +16,9 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
-        <PackageReference Include="Microsoft.OpenApi" Version="1.6.13" />
-        <PackageReference Include="nunit" Version="4.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
+        <PackageReference Include="Microsoft.OpenApi" Version="1.6.14" />
+        <PackageReference Include="nunit" Version="4.1.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />

--- a/Firebend.AutoCrud.Web.Sample/Extensions/SampleEntityExtensions.cs
+++ b/Firebend.AutoCrud.Web.Sample/Extensions/SampleEntityExtensions.cs
@@ -168,7 +168,8 @@ public static class SampleEntityExtensions
         generator.AddEntity<Guid, EfPerson>(person =>
             person.WithIncludes(x => x.Include(y => y.CustomFields)
                     .Include(y => y.Pets)
-                    .ThenInclude(y => y.CustomFields))
+                    .ThenInclude(y => y.CustomFields)
+                    .AsSplitQuery())
                 .AddElasticPool(manager =>
                     {
                         manager.ConnectionString = configuration.GetConnectionString("Elastic");
@@ -227,7 +228,7 @@ public static class SampleEntityExtensions
     public static EntityFrameworkEntityCrudGenerator AddEfPets(this EntityFrameworkEntityCrudGenerator generator,
         IConfiguration configuration) =>
         generator.AddEntity<Guid, EfPet>(person =>
-            person.WithIncludes(pets => pets.Include(x => x.Person))
+            person.WithIncludes(pets => pets.Include(x => x.Person).AsSplitQuery())
                 .AddElasticPool(manager =>
                     {
                         manager.ConnectionString = configuration.GetConnectionString("Elastic");

--- a/Firebend.AutoCrud.Web.Sample/Firebend.AutoCrud.Web.Sample.csproj
+++ b/Firebend.AutoCrud.Web.Sample/Firebend.AutoCrud.Web.Sample.csproj
@@ -24,17 +24,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MassTransit" Version="8.1.3" />
-    <PackageReference Include="MassTransit.Newtonsoft" Version="8.1.3" />
-    <PackageReference Include="MassTransit.RabbitMQ" Version="8.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="MassTransit" Version="8.2.0" />
+    <PackageReference Include="MassTransit.Newtonsoft" Version="8.2.0" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
   </ItemGroup>

--- a/Firebend.AutoCrud.Web/Firebend.AutoCrud.Web.csproj
+++ b/Firebend.AutoCrud.Web/Firebend.AutoCrud.Web.csproj
@@ -26,7 +26,7 @@
       <PackageReference Include="Humanizer.Core" Version="2.14.1" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-      <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.2" />
+      <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.3" />
       <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
       <PackageReference Include="System.ComponentModel.Annotations" Version="6.0.0-preview.4.21253.7" />
     </ItemGroup>


### PR DESCRIPTION
- when a change tracking db context provider is scaffolding the tables we will not concatenate the server and db name to the cache key to ensure all data stores are scaffold 
- the mongo clients are not cached by server name
   - it is best practice to keep this singletons and low instance counts

![image](https://github.com/firebend/auto-crud/assets/10537213/3fbfe4bc-0650-4345-8e28-cfbf3c7feb59)
