### PR TITLE
fix: change the AbstractEntitySearchService to use reflection to work with mongo v3 linq provider

### DIFF
--- a/Firebend.AutoCrud.ChangeTracking.EntityFramework/Implementations/EntityFrameworkChangeTrackingReadService.cs
+++ b/Firebend.AutoCrud.ChangeTracking.EntityFramework/Implementations/EntityFrameworkChangeTrackingReadService.cs
@@ -44,12 +44,7 @@ public class EntityFrameworkChangeTrackingReadService<TEntityKey, TEntity> :
         {
             query = query.Where(x => x.EntityId.Equals(searchRequest.EntityId));
 
-            var filter = GetSearchExpression(searchRequest);
-
-            if (filter != null)
-            {
-                query = query.Where(filter);
-            }
+            query = GetSearchExpressions(searchRequest).Aggregate(query, (current, expression) => current.Where(expression));
 
             if (_searchHandler != null)
             {

--- a/Firebend.AutoCrud.ChangeTracking.Mongo/Implementations/MongoChangeTrackingReadRepository.cs
+++ b/Firebend.AutoCrud.ChangeTracking.Mongo/Implementations/MongoChangeTrackingReadRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Firebend.AutoCrud.ChangeTracking.Interfaces;
@@ -51,12 +52,7 @@ public class MongoChangeTrackingReadRepository<TEntityKey, TEntity> :
 
         query = query.Where(x => x.EntityId.Equals(searchRequest.EntityId));
 
-        var filter = GetSearchExpression(searchRequest);
-
-        if (filter != null)
-        {
-            query = query.Where(filter);
-        }
+        query = GetSearchExpressions(searchRequest).Aggregate(query, (current, expression) => current.Where(expression));
 
         if (searchRequest.OrderBy == null)
         {

--- a/Firebend.AutoCrud.Core/Extensions/OrderByExtensions.cs
+++ b/Firebend.AutoCrud.Core/Extensions/OrderByExtensions.cs
@@ -56,7 +56,7 @@ public static class OrderByExtensions
     {
         if (source is null || source.Length <= 0)
         {
-            return Array.Empty<(Expression<Func<T, object>> order, bool ascending)>();
+            return [];
         }
 
         return source

--- a/Firebend.AutoCrud.EntityFramework/Services/EntityFrameworkEntitySearchService.cs
+++ b/Firebend.AutoCrud.EntityFramework/Services/EntityFrameworkEntitySearchService.cs
@@ -64,12 +64,7 @@ public class EntityFrameworkEntitySearchService<TKey, TEntity, TSearch> :
 
         await using (context)
         {
-            var expression = GetSearchExpression(request);
-
-            if (expression != null)
-            {
-                query = query.Where(expression);
-            }
+            query = GetSearchExpressions(request).Aggregate(query, (current, expression) => current.Where(expression));
 
             if (_searchHandler != null)
             {

--- a/Firebend.AutoCrud.IntegrationTests/BaseTest.cs
+++ b/Firebend.AutoCrud.IntegrationTests/BaseTest.cs
@@ -193,6 +193,10 @@ public abstract class BaseTest<
             .SetQueryParam("pageSize", 10)
             .SetQueryParam("isDeleted", "false")
             .SetQueryParam("orderBy", "createdDate:desc")
+            .SetQueryParam("CreatedStartDate", "1968-08-09")
+            .SetQueryParam("CreatedEndDate", "2068-08-09")
+            .SetQueryParam("ModifiedStartDate", "1968-08-09")
+            .SetQueryParam("ModifiedEndDate", "2068-08-09")
             .SetQueryParam("doCount", true)
             .GetAsync();
 

--- a/Firebend.AutoCrud.Mongo/Services/MongoEntitySearchService.cs
+++ b/Firebend.AutoCrud.Mongo/Services/MongoEntitySearchService.cs
@@ -65,12 +65,7 @@ public class MongoEntitySearchService<TKey, TEntity, TSearch> : AbstractEntitySe
 
         var query = await _readClient.GetQueryableAsync(firstStageFilter, entityTransaction, cancellationToken);
 
-        var expression = GetSearchExpression(request);
-
-        if (expression != null)
-        {
-            query = query.Where(expression);
-        }
+        query = GetSearchExpressions(request).Aggregate(query, (current, expression) => current.Where(expression));
 
         var paged = await _readClient.GetPagedResponseAsync(query, request, cancellationToken);
 


### PR DESCRIPTION
work around for https://jira.mongodb.org/browse/CSHARP-4535

BaseApiTest has been enhanced to send in CreatedStartDate, CreatedEndDate, ModifiedStartDate, and ModifiedEndDate to account for all branch of the AbstractEntitySearchService code 

![image](https://github.com/firebend/auto-crud/assets/10537213/798645dc-190d-4ae0-ad0a-f32c5309d460)
