### PR TITLE
feat!: better support for transactions in EF and Mongo

### DIFF
--- a/Firebend.AutoCrud.ChangeTracking.EntityFramework/DbContexts/ChangeTrackingDbContext.cs
+++ b/Firebend.AutoCrud.ChangeTracking.EntityFramework/DbContexts/ChangeTrackingDbContext.cs
@@ -28,6 +28,7 @@ public class ChangeTrackingDbContext<TKey, TEntity> : DbContext, IDbContext
 {
     public ChangeTrackingDbContext(DbContextOptions options) : base(options)
     {
+        Options = options;
     }
 
     /// <summary>
@@ -112,4 +113,7 @@ public class ChangeTrackingDbContext<TKey, TEntity> : DbContext, IDbContext
             .Metadata
             .SetValueComparer(new EntityFrameworkJsonComparer<TProperty>(settings));
     }
+
+    public DbContextOptions Options { get; }
+    public bool UseUserDefinedTransaction { get; set; }
 }

--- a/Firebend.AutoCrud.ChangeTracking.EntityFramework/Extensions.cs
+++ b/Firebend.AutoCrud.ChangeTracking.EntityFramework/Extensions.cs
@@ -65,7 +65,14 @@ public static class Extensions
             throw new Exception("Please configure the builder's db context first.");
         }
 
-        efBuilder.Services.AddPooledDbContextFactory<ChangeTrackingDbContext<TKey, TEntity>>(efBuilder.DbContextOptionsBuilder);
+        if (efBuilder.UsePooled)
+        {
+            efBuilder.Services.AddPooledDbContextFactory<ChangeTrackingDbContext<TKey, TEntity>>(efBuilder.DbContextOptionsBuilder);
+        }
+        else
+        {
+            efBuilder.Services.AddDbContextFactory<ChangeTrackingDbContext<TKey, TEntity>>(efBuilder.DbContextOptionsBuilder);
+        }
 
         configurator.Builder.WithRegistration<IDbContextProvider<Guid, ChangeTrackingEntity<TKey, TEntity>>, ChangeTrackingDbContextProvider<TKey, TEntity>>();
         configurator.Builder.WithRegistration<IChangeTrackingDbContextProvider<TKey, TEntity>, ChangeTrackingDbContextProvider<TKey, TEntity>>();

--- a/Firebend.AutoCrud.ChangeTracking.EntityFramework/Implementations/EntityFrameworkChangeTrackingService.cs
+++ b/Firebend.AutoCrud.ChangeTracking.EntityFramework/Implementations/EntityFrameworkChangeTrackingService.cs
@@ -21,7 +21,7 @@ public class EntityFrameworkChangeTrackingService<TEntityKey, TEntity> :
 {
     public EntityFrameworkChangeTrackingService(
         IChangeTrackingDbContextProvider<TEntityKey, TEntity> provider) :
-        base(provider, null)
+        base(provider, null, null)
     {
     }
 

--- a/Firebend.AutoCrud.ChangeTracking/Firebend.AutoCrud.ChangeTracking.csproj
+++ b/Firebend.AutoCrud.ChangeTracking/Firebend.AutoCrud.ChangeTracking.csproj
@@ -23,7 +23,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.6" />
+      <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.Core/Extensions/JsonPatchExtensions.cs
+++ b/Firebend.AutoCrud.Core/Extensions/JsonPatchExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using Firebend.AutoCrud.Core.Interfaces.Models;
 using Firebend.AutoCrud.Core.Models.Entities;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.JsonPatch.Operations;
@@ -50,4 +51,15 @@ public static class JsonPatchExtensions
                 _ => result.WasSuccessful = false);
         }
     }
+
+    public static bool HasOperationWithPath(this JsonPatchDocument document, string path)
+        => document?.Operations is not null &&
+           document.Operations.Any(x =>
+               x.path.Equals(path, StringComparison.InvariantCultureIgnoreCase));
+
+    public static bool IsOnlyModifiedEntityPatch(this JsonPatchDocument document)
+        => document?.Operations is not null &&
+        document.Operations.Count <= 2 &&
+        (document.HasOperationWithPath($"/{nameof(IModifiedEntity.CreatedDate)}") ||
+         document.HasOperationWithPath($"/{nameof(IModifiedEntity.ModifiedDate)}"));
 }

--- a/Firebend.AutoCrud.Core/Extensions/JsonPatchExtensions.cs
+++ b/Firebend.AutoCrud.Core/Extensions/JsonPatchExtensions.cs
@@ -52,14 +52,22 @@ public static class JsonPatchExtensions
         }
     }
 
-    public static bool HasOperationWithPath(this JsonPatchDocument document, string path)
-        => document?.Operations is not null &&
-           document.Operations.Any(x =>
-               x.path.Equals(path, StringComparison.InvariantCultureIgnoreCase));
+    public static bool HasOperationWithPath(this IJsonPatchDocument document, string path)
+    {
+        var operations = document?.GetOperations() ?? [];
 
-    public static bool IsOnlyModifiedEntityPatch(this JsonPatchDocument document)
-        => document?.Operations is not null &&
-        document.Operations.Count <= 2 &&
-        (document.HasOperationWithPath($"/{nameof(IModifiedEntity.CreatedDate)}") ||
-         document.HasOperationWithPath($"/{nameof(IModifiedEntity.ModifiedDate)}"));
+        return operations is not null &&
+               operations.Any(x =>
+                   x.path.Equals(path, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    public static bool IsOnlyModifiedEntityPatch(this IJsonPatchDocument document)
+    {
+        var operations = document?.GetOperations() ?? [];
+
+        return operations is not null &&
+               operations.Count <= 2 &&
+               (document.HasOperationWithPath($"/{nameof(IModifiedEntity.CreatedDate)}") ||
+                document.HasOperationWithPath($"/{nameof(IModifiedEntity.ModifiedDate)}"));
+    }
 }

--- a/Firebend.AutoCrud.Core/Extensions/JsonPatchExtensions.cs
+++ b/Firebend.AutoCrud.Core/Extensions/JsonPatchExtensions.cs
@@ -52,14 +52,13 @@ public static class JsonPatchExtensions
         }
     }
 
-    public static bool HasOperationWithPath(this IJsonPatchDocument document, string path)
-    {
-        var operations = document?.GetOperations() ?? [];
+    public static bool HasPath(this IList<Operation> operations, string path) =>
+        operations is not null &&
+        operations.Any(x =>
+            x.path.Equals(path, StringComparison.InvariantCultureIgnoreCase));
 
-        return operations is not null &&
-               operations.Any(x =>
-                   x.path.Equals(path, StringComparison.InvariantCultureIgnoreCase));
-    }
+    public static bool HasPath(this IJsonPatchDocument document, string path)
+        => (document?.GetOperations() ?? []).HasPath(path);
 
     public static bool IsOnlyModifiedEntityPatch(this IJsonPatchDocument document)
     {
@@ -67,7 +66,7 @@ public static class JsonPatchExtensions
 
         return operations is not null &&
                operations.Count <= 2 &&
-               (document.HasOperationWithPath($"/{nameof(IModifiedEntity.CreatedDate)}") ||
-                document.HasOperationWithPath($"/{nameof(IModifiedEntity.ModifiedDate)}"));
+               (operations.HasPath($"/{nameof(IModifiedEntity.CreatedDate)}") ||
+                operations.HasPath($"/{nameof(IModifiedEntity.ModifiedDate)}"));
     }
 }

--- a/Firebend.AutoCrud.Core/Implementations/DomainEvents/DefaultDomainEventPublisherService.cs
+++ b/Firebend.AutoCrud.Core/Implementations/DomainEvents/DefaultDomainEventPublisherService.cs
@@ -39,7 +39,7 @@ public class DefaultDomainEventPublisherService<TKey, TEntity> : IDomainEventPub
 
     public async Task<TEntity> ReadAndPublishAddedEventAsync(TKey key, IEntityTransaction transaction, CancellationToken cancellationToken)
     {
-        var entity = await _readService.GetByKeyAsync(key, cancellationToken);
+        var entity = await _readService.GetByKeyAsync(key, transaction, cancellationToken);
 
         if (!_hasPublisher)
         {
@@ -66,7 +66,7 @@ public class DefaultDomainEventPublisherService<TKey, TEntity> : IDomainEventPub
         Func<TEntity, TEntity, JsonPatchDocument<TEntity>> patchGenerator,
         CancellationToken cancellationToken)
     {
-        var entity = await _readService.GetByKeyAsync(key, cancellationToken);
+        var entity = await _readService.GetByKeyAsync(key, transaction, cancellationToken);
 
         if (!_hasPublisher)
         {

--- a/Firebend.AutoCrud.Core/Implementations/DomainEvents/DomainEventEntityTransactionOutboxEnrollment.cs
+++ b/Firebend.AutoCrud.Core/Implementations/DomainEvents/DomainEventEntityTransactionOutboxEnrollment.cs
@@ -1,0 +1,5 @@
+using Firebend.AutoCrud.Core.Models.Entities;
+
+namespace Firebend.AutoCrud.Core.Implementations.DomainEvents;
+
+public class DomainEventEntityTransactionOutboxEnrollment : FunctionTransactionOutboxEnrollment;

--- a/Firebend.AutoCrud.Core/Implementations/DomainEvents/ServiceProviderDomainEventEntityTransactionOutboxEnrollment.cs
+++ b/Firebend.AutoCrud.Core/Implementations/DomainEvents/ServiceProviderDomainEventEntityTransactionOutboxEnrollment.cs
@@ -1,0 +1,3 @@
+namespace Firebend.AutoCrud.Core.Implementations.DomainEvents;
+
+public class ServiceProviderDomainEventEntityTransactionOutboxEnrollment : DomainEventEntityTransactionOutboxEnrollment;

--- a/Firebend.AutoCrud.Core/Implementations/DomainEvents/ServiceProviderDomainEventPublisher.cs
+++ b/Firebend.AutoCrud.Core/Implementations/DomainEvents/ServiceProviderDomainEventPublisher.cs
@@ -13,12 +13,13 @@ public class ServiceProviderDomainEventPublisher<TKey, TEntity> : IEntityDomainE
     where TKey : struct
     where TEntity : class, IEntity<TKey>
 {
-    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly IServiceProvider _serviceProvider;
 
-    public ServiceProviderDomainEventPublisher(IServiceScopeFactory serviceScopeFactory)
+    public ServiceProviderDomainEventPublisher(IServiceProvider serviceProvider)
     {
-        _serviceScopeFactory = serviceScopeFactory;
+        _serviceProvider = serviceProvider;
     }
+
 
     public Task PublishEntityAddEventAsync(EntityAddedDomainEvent<TEntity> domainEvent,
         IEntityTransaction entityTransaction,
@@ -83,11 +84,7 @@ public class ServiceProviderDomainEventPublisher<TKey, TEntity> : IEntityDomainE
         CancellationToken cancellationToken)
         where TSubscriber : IDisposable
     {
-        using var scope = _serviceScopeFactory.CreateScope();
-
-        var subscribers = scope
-            .ServiceProvider
-            .GetServices<TSubscriber>();
+        var subscribers = _serviceProvider.GetServices<TSubscriber>();
 
         var subscribersArray = subscribers as TSubscriber[] ?? subscribers.ToArray();
 

--- a/Firebend.AutoCrud.Core/Implementations/DomainEvents/ServiceProviderDomainEventPublisher.cs
+++ b/Firebend.AutoCrud.Core/Implementations/DomainEvents/ServiceProviderDomainEventPublisher.cs
@@ -24,45 +24,57 @@ public class ServiceProviderDomainEventPublisher<TKey, TEntity> : IEntityDomainE
         IEntityTransaction entityTransaction,
         CancellationToken cancellationToken = default)
     {
-        Task PublishAsync(CancellationToken token) =>
-            ExecuteSubscribers<IEntityAddedDomainEventSubscriber<TEntity>, EntityAddedDomainEvent<TEntity>>(
-                domainEvent,
-            (subscriber, de, ct) => subscriber.EntityAddedAsync(de, ct),
-                cancellationToken);
+        return entityTransaction == null
+            ? PublishAsync(cancellationToken)
+            : entityTransaction
+                .AddFunctionEnrollmentAsync<TEntity, ServiceProviderDomainEventEntityTransactionOutboxEnrollment>(
+                    PublishAsync, cancellationToken);
 
-        return entityTransaction == null ?
-            PublishAsync(cancellationToken) :
-            entityTransaction.AddFunctionEnrollmentAsync(PublishAsync, cancellationToken);
+        Task PublishAsync(CancellationToken token)
+        {
+            return ExecuteSubscribers<IEntityAddedDomainEventSubscriber<TEntity>, EntityAddedDomainEvent<TEntity>>(
+                domainEvent,
+                (subscriber, de, ct) => subscriber.EntityAddedAsync(de, ct),
+                cancellationToken);
+        }
     }
 
     public Task PublishEntityDeleteEventAsync(EntityDeletedDomainEvent<TEntity> domainEvent,
         IEntityTransaction entityTransaction,
         CancellationToken cancellationToken = default)
     {
-        Task PublishAsync(CancellationToken token) =>
-            ExecuteSubscribers<IEntityDeletedDomainEventSubscriber<TEntity>, EntityDeletedDomainEvent<TEntity>>(
+        return entityTransaction == null
+            ? PublishAsync(cancellationToken)
+            : entityTransaction
+                .AddFunctionEnrollmentAsync<TEntity, ServiceProviderDomainEventEntityTransactionOutboxEnrollment>(
+                    PublishAsync, cancellationToken);
+
+        Task PublishAsync(CancellationToken token)
+        {
+            return ExecuteSubscribers<IEntityDeletedDomainEventSubscriber<TEntity>, EntityDeletedDomainEvent<TEntity>>(
                 domainEvent,
                 (subscriber, de, ct) => subscriber.EntityDeletedAsync(de, ct),
                 cancellationToken);
-
-        return entityTransaction == null ?
-            PublishAsync(cancellationToken) :
-            entityTransaction.AddFunctionEnrollmentAsync(PublishAsync, cancellationToken);
+        }
     }
 
     public Task PublishEntityUpdatedEventAsync(EntityUpdatedDomainEvent<TEntity> domainEvent,
         IEntityTransaction entityTransaction,
         CancellationToken cancellationToken = default)
     {
-        Task PublishAsync(CancellationToken token) =>
-            ExecuteSubscribers<IEntityUpdatedDomainEventSubscriber<TEntity>, EntityUpdatedDomainEvent<TEntity>>(
+        return entityTransaction == null
+            ? PublishAsync(cancellationToken)
+            : entityTransaction
+                .AddFunctionEnrollmentAsync<TEntity, ServiceProviderDomainEventEntityTransactionOutboxEnrollment>(
+                    PublishAsync, cancellationToken);
+
+        Task PublishAsync(CancellationToken token)
+        {
+            return ExecuteSubscribers<IEntityUpdatedDomainEventSubscriber<TEntity>, EntityUpdatedDomainEvent<TEntity>>(
                 domainEvent,
                 (subscriber, de, ct) => subscriber.EntityUpdatedAsync(de, ct),
                 cancellationToken);
-
-        return entityTransaction == null ?
-            PublishAsync(cancellationToken) :
-            entityTransaction.AddFunctionEnrollmentAsync(PublishAsync, cancellationToken);
+        }
     }
 
     private async Task ExecuteSubscribers<TSubscriber, TEvent>(
@@ -105,7 +117,6 @@ public class ServiceProviderDomainEventPublisher<TKey, TEntity> : IEntityDomainE
             // ReSharper disable once EmptyGeneralCatchClause
             catch
             {
-
             }
         }
     }

--- a/Firebend.AutoCrud.Core/Implementations/Entities/ClientRequestTransactionManager.cs
+++ b/Firebend.AutoCrud.Core/Implementations/Entities/ClientRequestTransactionManager.cs
@@ -14,10 +14,8 @@ namespace Firebend.AutoCrud.Core.Implementations.Entities;
 
 public class ClientRequestTransactionManager : ISessionTransactionManager
 {
-    private class QueuedTransaction
+    private record QueuedTransaction(IEntityTransaction Transaction, DateTimeOffset StartedDate)
     {
-        public IEntityTransaction Transaction { get; init; }
-        public DateTimeOffset StartedDate { get; init; }
         public bool Removed { get; set; }
     }
 
@@ -177,7 +175,7 @@ public class ClientRequestTransactionManager : ISessionTransactionManager
         }
 
         _logger.LogDebug("{SessionId}: Adding transaction {TransactionId} to session", _sessionId, transaction.Id);
-        _transactions.Add(new QueuedTransaction { Transaction = transaction, StartedDate = transaction.StartedDate });
+        _transactions.Add(new QueuedTransaction(transaction, transaction.StartedDate));
     }
 
     private void RemoveTransaction(string key, Guid transactionId)

--- a/Firebend.AutoCrud.Core/Interfaces/Models/EntityTransactionExtensions.cs
+++ b/Firebend.AutoCrud.Core/Interfaces/Models/EntityTransactionExtensions.cs
@@ -7,8 +7,16 @@ namespace Firebend.AutoCrud.Core.Interfaces.Models;
 
 public static class EntityTransactionExtensions
 {
-    public static Task AddFunctionEnrollmentAsync(this IEntityTransaction source,
+    public static Task AddFunctionEnrollmentAsync<TEntity, TEnrollment>(this IEntityTransaction source,
         Func<CancellationToken, Task> func,
         CancellationToken cancellationToken)
-        => source.Outbox.AddEnrollmentAsync(source.Id.ToString(), new FunctionTransactionOutboxEnrollment(func), cancellationToken);
+    where TEntity : class
+    where TEnrollment : FunctionTransactionOutboxEnrollment, new()
+    {
+        var handler = new TEnrollment();
+        handler.SetFunc(func);
+        var enrollment = new EntityTransactionOutboxEnrollment(source.Id.ToString(), handler, typeof(TEntity));
+
+        return source.Outbox.AddEnrollmentAsync(enrollment, cancellationToken);
+    }
 }

--- a/Firebend.AutoCrud.Core/Interfaces/Services/Entities/IEntityTransactionOutbox.cs
+++ b/Firebend.AutoCrud.Core/Interfaces/Services/Entities/IEntityTransactionOutbox.cs
@@ -1,13 +1,20 @@
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Firebend.AutoCrud.Core.Models.Entities;
 
 namespace Firebend.AutoCrud.Core.Interfaces.Services.Entities;
 
 public interface IEntityTransactionOutbox
 {
-    Task AddEnrollmentAsync(string transactionId, IEntityTransactionOutboxEnrollment enrollment, CancellationToken cancellationToken);
+    Task AddEnrollmentAsync(EntityTransactionOutboxEnrollment enrollment, CancellationToken cancellationToken);
 
     Task InvokeEnrollmentsAsync(string transactionId, CancellationToken cancellationToken);
 
     Task ClearEnrollmentsAsync(string transactionId, CancellationToken cancellationToken);
+
+    Task<Dictionary<string, List<EntityTransactionOutboxEnrollment>>> GetEnrollmentsAsync(CancellationToken cancellationToken);
+
+    Action<string, List<EntityTransactionOutboxEnrollment>> OnBeforeInvokeEnrollments { get; set; }
 }

--- a/Firebend.AutoCrud.Core/Models/Entities/EntityTransactionOutboxEnrollment.cs
+++ b/Firebend.AutoCrud.Core/Models/Entities/EntityTransactionOutboxEnrollment.cs
@@ -1,0 +1,9 @@
+using System;
+using Firebend.AutoCrud.Core.Interfaces.Services.Entities;
+
+namespace Firebend.AutoCrud.Core.Models.Entities;
+
+public record EntityTransactionOutboxEnrollment(
+    string TransactionId,
+    IEntityTransactionOutboxEnrollment Enrollment,
+    Type EntityType);

--- a/Firebend.AutoCrud.Core/Models/Entities/FunctionTransactionOutboxEnrollment.cs
+++ b/Firebend.AutoCrud.Core/Models/Entities/FunctionTransactionOutboxEnrollment.cs
@@ -7,12 +7,13 @@ namespace Firebend.AutoCrud.Core.Models.Entities;
 
 public class FunctionTransactionOutboxEnrollment : IEntityTransactionOutboxEnrollment
 {
-    private readonly Func<CancellationToken, Task> _func;
+    private Func<CancellationToken, Task> _func;
 
-    public FunctionTransactionOutboxEnrollment(Func<CancellationToken, Task> func)
+    public FunctionTransactionOutboxEnrollment()
     {
-        _func = func;
     }
+
+    public void SetFunc(Func<CancellationToken, Task> func) => _func = func;
 
     public Task ActAsync(CancellationToken cancellationToken) => _func(cancellationToken);
 }

--- a/Firebend.AutoCrud.CustomFields.EntityFramework/EfCustomFieldsConfigurator.cs
+++ b/Firebend.AutoCrud.CustomFields.EntityFramework/EfCustomFieldsConfigurator.cs
@@ -63,7 +63,8 @@ public class EfCustomFieldsConfigurator<TBuilder, TKey, TEntity> : EntityCrudCon
         var customFieldsBuilder = new EntityFrameworkEntityBuilder<Guid, EfCustomFieldsModel<TKey, TEntity>>(
             Builder.Services,
             Builder.DbContextType,
-            Builder.DbContextOptionsBuilder)
+            Builder.DbContextOptionsBuilder,
+            Builder.UsePooled)
         {
             SignatureBase = $"{typeof(TEntity).Name}_CustomFields",
         };
@@ -102,7 +103,8 @@ public class EfCustomFieldsConfigurator<TBuilder, TKey, TEntity> : EntityCrudCon
         var customFieldsBuilder = new EntityFrameworkEntityBuilder<Guid, EfCustomFieldsModelTenant<TKey, TEntity, TTenantKey>>(
             Builder.Services,
             Builder.DbContextType,
-            Builder.DbContextOptionsBuilder)
+            Builder.DbContextOptionsBuilder,
+            Builder.UsePooled)
         {
             SignatureBase = $"{typeof(TEntity).Name}_CustomFields"
         };

--- a/Firebend.AutoCrud.CustomFields.EntityFramework/Firebend.AutoCrud.CustomFields.EntityFramework.csproj
+++ b/Firebend.AutoCrud.CustomFields.EntityFramework/Firebend.AutoCrud.CustomFields.EntityFramework.csproj
@@ -27,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
     </ItemGroup>
 
 </Project>

--- a/Firebend.AutoCrud.DomainEvents.MassTransit/MassTransitDomainEventEntityTransactionOutboxEnrollment.cs
+++ b/Firebend.AutoCrud.DomainEvents.MassTransit/MassTransitDomainEventEntityTransactionOutboxEnrollment.cs
@@ -1,0 +1,5 @@
+using Firebend.AutoCrud.Core.Implementations.DomainEvents;
+
+namespace Firebend.AutoCrud.DomainEvents.MassTransit;
+
+public class MassTransitDomainEventEntityTransactionOutboxEnrollment : DomainEventEntityTransactionOutboxEnrollment;

--- a/Firebend.AutoCrud.DomainEvents.MassTransit/MassTransitDomainEventPublisher.cs
+++ b/Firebend.AutoCrud.DomainEvents.MassTransit/MassTransitDomainEventPublisher.cs
@@ -34,13 +34,8 @@ public class MassTransitDomainEventPublisher<TKey, TEntity> : IEntityDomainEvent
         => PublishAsync(domainEvent, transaction, cancellationToken);
 
     private Task PublishAsync<TDomainEvent>(TDomainEvent domainEvent, IEntityTransaction transaction, CancellationToken cancellationToken)
-    {
-        if (transaction == null)
-        {
-            return _bus.Publish(domainEvent, cancellationToken);
-        }
-
-        return transaction.AddFunctionEnrollmentAsync(ct =>
-            _bus.Publish(domainEvent, ct), cancellationToken);
-    }
+        => transaction == null
+            ? _bus.Publish(domainEvent, cancellationToken)
+            : transaction.AddFunctionEnrollmentAsync<TEntity, MassTransitDomainEventEntityTransactionOutboxEnrollment>(
+                ct => _bus.Publish(domainEvent, ct), cancellationToken);
 }

--- a/Firebend.AutoCrud.EntityFramework.Elastic/AutoCrudSqlServerBuilderHelper.cs
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/AutoCrudSqlServerBuilderHelper.cs
@@ -1,0 +1,29 @@
+using System;
+using Firebend.AutoCrud.EntityFramework.CustomCommands;
+using Firebend.AutoCrud.EntityFramework.Elastic.Implementations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Firebend.AutoCrud.EntityFramework.Elastic;
+
+public class SqlServerBuilder
+{
+    public static Action<IServiceProvider, DbContextOptionsBuilder> Get(
+        Action<DbContextOptionsBuilder> configureBuilder = null,
+        Action<SqlServerDbContextOptionsBuilder> configureSqlServer = null) =>
+        (provider, builder) =>
+        {
+            builder.UseSqlServer(o =>
+                {
+                    o.ExecutionStrategy(dependencies => new AutoCrudAzureExecutionStrategy(provider,
+                        dependencies,
+                        6,
+                        TimeSpan.FromSeconds(30)));
+
+                    configureSqlServer?.Invoke(o);
+                })
+                .AddFirebendFunctions();
+
+            configureBuilder?.Invoke(builder);
+        };
+}

--- a/Firebend.AutoCrud.EntityFramework.Elastic/AutoCrudSqlServerBuilderHelper.cs
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/AutoCrudSqlServerBuilderHelper.cs
@@ -6,9 +6,9 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Firebend.AutoCrud.EntityFramework.Elastic;
 
-public class SqlServerBuilder
+public class AutoCrudSqlServerOptionsBuilder
 {
-    public static Action<IServiceProvider, DbContextOptionsBuilder> Get(
+    public static Action<IServiceProvider, DbContextOptionsBuilder> Build(
         Action<DbContextOptionsBuilder> configureBuilder = null,
         Action<SqlServerDbContextOptionsBuilder> configureSqlServer = null) =>
         (provider, builder) =>

--- a/Firebend.AutoCrud.EntityFramework.Elastic/AutoCrudSqlServerBuilderHelper.cs
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/AutoCrudSqlServerBuilderHelper.cs
@@ -15,8 +15,7 @@ public class AutoCrudSqlServerOptionsBuilder
         {
             builder.UseSqlServer(o =>
                 {
-                    o.ExecutionStrategy(dependencies => new AutoCrudAzureExecutionStrategy(provider,
-                        dependencies,
+                    o.ExecutionStrategy(dependencies => new AutoCrudSqlServerExecutionStrategy(dependencies,
                         6,
                         TimeSpan.FromSeconds(30)));
 

--- a/Firebend.AutoCrud.EntityFramework.Elastic/ElasticPoolConfigurator.cs
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/ElasticPoolConfigurator.cs
@@ -1,10 +1,15 @@
 using System;
 using Firebend.AutoCrud.Core.Abstractions.Configurators;
 using Firebend.AutoCrud.Core.Interfaces.Models;
+using Firebend.AutoCrud.EntityFramework.CustomCommands;
 using Firebend.AutoCrud.EntityFramework.Elastic.Implementations;
 using Firebend.AutoCrud.EntityFramework.Elastic.Interfaces;
 using Firebend.AutoCrud.EntityFramework.Elastic.Models;
+using Firebend.AutoCrud.EntityFramework.Implementations;
 using Firebend.AutoCrud.EntityFramework.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Firebend.AutoCrud.EntityFramework.Elastic;
 

--- a/Firebend.AutoCrud.EntityFramework.Elastic/Extensions/ElasticEntityFrameworkExtensions.cs
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/Extensions/ElasticEntityFrameworkExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using Firebend.AutoCrud.Core.Interfaces.Models;
 using Firebend.AutoCrud.EntityFramework.Elastic.Implementations;
 using Firebend.AutoCrud.EntityFramework.Elastic.Models;
+using Firebend.AutoCrud.EntityFramework.Implementations;
 using Firebend.AutoCrud.EntityFramework.Interfaces;
 
 namespace Firebend.AutoCrud.EntityFramework.Elastic.Extensions;

--- a/Firebend.AutoCrud.EntityFramework.Elastic/Firebend.AutoCrud.EntityFramework.Elastic.csproj
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/Firebend.AutoCrud.EntityFramework.Elastic.csproj
@@ -24,7 +24,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Azure.SqlDatabase.ElasticScale.Client" Version="2.4.1" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Firebend.AutoCrud.EntityFramework.Elastic/Implementations/AutoCrudAzureExecutionStrategy.cs
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/Implementations/AutoCrudAzureExecutionStrategy.cs
@@ -1,0 +1,64 @@
+using System;
+using Firebend.AutoCrud.EntityFramework.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Firebend.AutoCrud.EntityFramework.Elastic.Implementations;
+
+public class AutoCrudAzureExecutionStrategy : ExecutionStrategy
+{
+    private readonly IExecutionStrategy _strategy;
+
+    public AutoCrudAzureExecutionStrategy(DbContext context, int maxRetryCount, TimeSpan maxRetryDelay) : base(context, maxRetryCount, maxRetryDelay)
+    {
+        var shouldUseUserTransaction = context is IDbContext { UseUserDefinedTransaction: true };
+
+        if (shouldUseUserTransaction)
+        {
+            Console.WriteLine("******************************* USER TRAN *****************");
+            _strategy = new NonRetryingExecutionStrategy(context);
+        }
+        else
+        {
+            _strategy = new SqlServerRetryingExecutionStrategy(context, maxRetryCount, maxRetryDelay, null);
+        }
+    }
+
+    public AutoCrudAzureExecutionStrategy(IServiceProvider provider,
+        ExecutionStrategyDependencies dependencies,
+        int maxRetryCount,
+        TimeSpan maxRetryDelay) : base(dependencies, maxRetryCount, maxRetryDelay)
+    {
+        var shouldUseUserTransaction = dependencies.CurrentContext.Context is IDbContext { UseUserDefinedTransaction: true };
+
+        if (shouldUseUserTransaction)
+        {
+            Console.WriteLine("******************************* USER TRAN *****************");
+            _strategy = new NonRetryingExecutionStrategy(dependencies);
+        }
+        else
+        {
+            _strategy = new SqlServerRetryingExecutionStrategy(dependencies, maxRetryCount, maxRetryDelay, null);
+        }
+    }
+
+    protected override void OnFirstExecution()
+    {
+        this.ExceptionsEncountered.Clear();
+    }
+
+    protected override bool ShouldRetryOn(Exception exception)
+    {
+        if (_strategy is NonRetryingExecutionStrategy)
+        {
+            return false;
+        }
+
+#pragma warning disable EF1001
+        return SqlServerTransientExceptionDetector.ShouldRetryOn(exception);
+#pragma warning restore EF1001
+    }
+}

--- a/Firebend.AutoCrud.EntityFramework.Elastic/Implementations/AutoCrudSqlServerExecutionStrategy.cs
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/Implementations/AutoCrudSqlServerExecutionStrategy.cs
@@ -6,14 +6,14 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Firebend.AutoCrud.EntityFramework.Elastic.Implementations;
 
-public class AutoCrudAzureExecutionStrategy : ExecutionStrategy
+public class AutoCrudSqlServerExecutionStrategy : ExecutionStrategy
 {
     private readonly IExecutionStrategy _strategy;
 
     private static bool IsDbContextUsingUserTransactions(DbContext context)
         => context is IDbContext { UseUserDefinedTransaction: true };
 
-    public AutoCrudAzureExecutionStrategy(DbContext context, int maxRetryCount, TimeSpan maxRetryDelay) : base(context, maxRetryCount, maxRetryDelay)
+    public AutoCrudSqlServerExecutionStrategy(DbContext context, int maxRetryCount, TimeSpan maxRetryDelay) : base(context, maxRetryCount, maxRetryDelay)
     {
         var shouldUseUserTransaction = IsDbContextUsingUserTransactions(context);
 
@@ -28,8 +28,7 @@ public class AutoCrudAzureExecutionStrategy : ExecutionStrategy
     }
 
 
-    public AutoCrudAzureExecutionStrategy(IServiceProvider provider,
-        ExecutionStrategyDependencies dependencies,
+    public AutoCrudSqlServerExecutionStrategy(ExecutionStrategyDependencies dependencies,
         int maxRetryCount,
         TimeSpan maxRetryDelay) : base(dependencies, maxRetryCount, maxRetryDelay)
     {

--- a/Firebend.AutoCrud.EntityFramework.Elastic/Implementations/ConstraintUpdateExceptionHandler.cs
+++ b/Firebend.AutoCrud.EntityFramework.Elastic/Implementations/ConstraintUpdateExceptionHandler.cs
@@ -59,7 +59,7 @@ public class ConstraintUpdateExceptionHandler<TKey, TEntity>
             return OnUniqueConstraintUnresolved(entity, sqlException);
         }
 
-        var constraint = constraintSplit[1][..constraintSplit[1].IndexOf("'", StringComparison.Ordinal)];
+        var constraint = constraintSplit[1][..constraintSplit[1].IndexOf('\'')];
 
         var tableIndex = GetConstraint<TableIndex, IIndex>(
             dbContext,
@@ -112,7 +112,7 @@ public class ConstraintUpdateExceptionHandler<TKey, TEntity>
             return OnConstraintUnresolved(entity, sqlException);
         }
 
-        var constraint = constraintSplit[1][..constraintSplit[1].IndexOf("\"", StringComparison.Ordinal)];
+        var constraint = constraintSplit[1][..constraintSplit[1].IndexOf('"')];
 
         var foreignKey = GetConstraint<ForeignKeyConstraint, IForeignKey>(
             dbContext,

--- a/Firebend.AutoCrud.EntityFramework.Sample/DbContexts/AppDbContext.cs
+++ b/Firebend.AutoCrud.EntityFramework.Sample/DbContexts/AppDbContext.cs
@@ -1,10 +1,10 @@
-using Firebend.AutoCrud.EntityFramework.Interfaces;
+using Firebend.AutoCrud.EntityFramework.Abstractions;
 using Firebend.AutoCrud.EntityFramework.Sample.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace Firebend.AutoCrud.EntityFramework.Sample.DbContexts;
 
-public sealed class AppDbContext : DbContext, IDbContext
+public sealed class AppDbContext : AbstractDbContext
 {
     public AppDbContext(DbContextOptions options) : base(options)
     {

--- a/Firebend.AutoCrud.EntityFramework.Sample/Firebend.AutoCrud.EntityFramework.Sample.csproj
+++ b/Firebend.AutoCrud.EntityFramework.Sample/Firebend.AutoCrud.EntityFramework.Sample.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     </ItemGroup>

--- a/Firebend.AutoCrud.EntityFramework.Sample/SampleHostedService.cs
+++ b/Firebend.AutoCrud.EntityFramework.Sample/SampleHostedService.cs
@@ -30,13 +30,12 @@ public class SampleHostedService : BackgroundService
         {
             _logger = logger;
 
-            using var scope = serviceProvider.CreateScope();
-            _createService = scope.ServiceProvider.GetService<IEntityCreateService<Guid, Person>>();
-            _updateService = scope.ServiceProvider.GetService<IEntityUpdateService<Guid, Person>>();
-            _readService = scope.ServiceProvider.GetService<IPersonReadRepository>();
-            _searchService = scope.ServiceProvider.GetService<IEntitySearchService<Guid, Person, EntityRequest>>();
+            _createService = serviceProvider.GetService<IEntityCreateService<Guid, Person>>();
+            _updateService = serviceProvider.GetService<IEntityUpdateService<Guid, Person>>();
+            _readService = serviceProvider.GetService<IPersonReadRepository>();
+            _searchService = serviceProvider.GetService<IEntitySearchService<Guid, Person, EntityRequest>>();
 
-            var context = scope.ServiceProvider.GetService<AppDbContext>();
+            var context = serviceProvider.GetService<AppDbContext>();
 
             if (context == null)
             {

--- a/Firebend.AutoCrud.EntityFramework/Abstractions/AbstractDbContext.cs
+++ b/Firebend.AutoCrud.EntityFramework/Abstractions/AbstractDbContext.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Firebend.AutoCrud.EntityFramework.Abstractions;
 
-public class AbstractDbContext: DbContext, IDbContext
+public class AbstractDbContext : DbContext, IDbContext
 {
     public AbstractDbContext(DbContextOptions options) : base(options)
     {

--- a/Firebend.AutoCrud.EntityFramework/Abstractions/AbstractDbContext.cs
+++ b/Firebend.AutoCrud.EntityFramework/Abstractions/AbstractDbContext.cs
@@ -1,0 +1,16 @@
+using Firebend.AutoCrud.EntityFramework.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Firebend.AutoCrud.EntityFramework.Abstractions;
+
+public class AbstractDbContext: DbContext, IDbContext
+{
+    public AbstractDbContext(DbContextOptions options) : base(options)
+    {
+        Options = options;
+    }
+
+    public DbContextOptions Options { get; }
+
+    public bool UseUserDefinedTransaction { get; set; }
+}

--- a/Firebend.AutoCrud.EntityFramework/Abstractions/AbstractDbContextRepo.cs
+++ b/Firebend.AutoCrud.EntityFramework/Abstractions/AbstractDbContextRepo.cs
@@ -18,11 +18,11 @@ public abstract class AbstractDbContextRepo<TKey, TEntity> : BaseDisposable
     where TKey : struct
     where TEntity : class, IEntity<TKey>, new()
 {
-    private readonly IDbContextProvider<TKey, TEntity> _provider;
+    protected IDbContextProvider<TKey, TEntity> Provider { get; }
 
     protected AbstractDbContextRepo(IDbContextProvider<TKey, TEntity> provider)
     {
-        _provider = provider;
+        Provider = provider;
     }
 
     protected virtual async Task<IDbContext> GetDbContextAsync(IEntityTransaction entityTransaction, CancellationToken cancellationToken)
@@ -31,7 +31,7 @@ public abstract class AbstractDbContextRepo<TKey, TEntity> : BaseDisposable
 
         if (entityTransaction == null)
         {
-            context = await _provider.GetDbContextAsync(cancellationToken);
+            context = await Provider.GetDbContextAsync(cancellationToken);
         }
         else
         {
@@ -42,7 +42,7 @@ public abstract class AbstractDbContextRepo<TKey, TEntity> : BaseDisposable
 
             var transaction = efTransaction.ContextTransaction.GetDbTransaction();
 
-            context = await _provider.GetDbContextAsync(transaction, cancellationToken);
+            context = await Provider.GetDbContextAsync(transaction, cancellationToken);
         }
 
         return context;

--- a/Firebend.AutoCrud.EntityFramework/Abstractions/AbstractDbContextSaveRepo.cs
+++ b/Firebend.AutoCrud.EntityFramework/Abstractions/AbstractDbContextSaveRepo.cs
@@ -1,0 +1,35 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Firebend.AutoCrud.Core.Interfaces.Models;
+using Firebend.AutoCrud.EntityFramework.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Firebend.AutoCrud.EntityFramework.Abstractions;
+
+public class AbstractDbContextSaveRepo<TKey, TEntity> : AbstractDbContextRepo<TKey, TEntity>
+    where TKey : struct
+    where TEntity : class, IEntity<TKey>, new()
+{
+    protected  IEntityFrameworkDbUpdateExceptionHandler<TKey, TEntity> ExceptionHandler { get; }
+
+    public AbstractDbContextSaveRepo(IDbContextProvider<TKey, TEntity> provider,
+        IEntityFrameworkDbUpdateExceptionHandler<TKey, TEntity> exceptionHandler) : base(provider)
+    {
+        ExceptionHandler = exceptionHandler;
+    }
+
+    protected virtual async Task SaveAsync(TEntity entity, IDbContext context, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex)
+        {
+            if (!(ExceptionHandler?.HandleException(context, entity, ex) ?? false))
+            {
+                throw;
+            }
+        }
+    }
+}

--- a/Firebend.AutoCrud.EntityFramework/Abstractions/AbstractDbContextSaveRepo.cs
+++ b/Firebend.AutoCrud.EntityFramework/Abstractions/AbstractDbContextSaveRepo.cs
@@ -10,7 +10,7 @@ public class AbstractDbContextSaveRepo<TKey, TEntity> : AbstractDbContextRepo<TK
     where TKey : struct
     where TEntity : class, IEntity<TKey>, new()
 {
-    protected  IEntityFrameworkDbUpdateExceptionHandler<TKey, TEntity> ExceptionHandler { get; }
+    protected IEntityFrameworkDbUpdateExceptionHandler<TKey, TEntity> ExceptionHandler { get; }
 
     public AbstractDbContextSaveRepo(IDbContextProvider<TKey, TEntity> provider,
         IEntityFrameworkDbUpdateExceptionHandler<TKey, TEntity> exceptionHandler) : base(provider)

--- a/Firebend.AutoCrud.EntityFramework/Client/DbContextProvider.cs
+++ b/Firebend.AutoCrud.EntityFramework/Client/DbContextProvider.cs
@@ -1,6 +1,7 @@
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Transactions;
 using Firebend.AutoCrud.Core.Interfaces.Models;
 using Firebend.AutoCrud.EntityFramework.HostedServices;
 using Firebend.AutoCrud.EntityFramework.Interfaces;

--- a/Firebend.AutoCrud.EntityFramework/Client/DbContextProvider.cs
+++ b/Firebend.AutoCrud.EntityFramework/Client/DbContextProvider.cs
@@ -1,7 +1,6 @@
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Transactions;
 using Firebend.AutoCrud.Core.Interfaces.Models;
 using Firebend.AutoCrud.EntityFramework.HostedServices;
 using Firebend.AutoCrud.EntityFramework.Interfaces;
@@ -69,6 +68,7 @@ public class DbContextProvider<TKey, TEntity, TContext> : IDbContextProvider<TKe
         await AutoCrudEfMigrationsMediator.HaveMigrationsRan.Task;
 
         var dbContext = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        dbContext.UseUserDefinedTransaction = true;
         dbContext.Database.SetDbConnection(transaction.Connection);
         await dbContext.Database.UseTransactionAsync(transaction, cancellationToken);
 

--- a/Firebend.AutoCrud.EntityFramework/Client/EntityFrameworkDeleteClient.cs
+++ b/Firebend.AutoCrud.EntityFramework/Client/EntityFrameworkDeleteClient.cs
@@ -77,7 +77,7 @@ public class EntityFrameworkDeleteClient<TKey, TEntity> : AbstractDbContextRepo<
         IEntityTransaction transaction,
         CancellationToken cancellationToken)
     {
-        var previous = await _readService.GetAllAsync(filter, cancellationToken);
+        var previous = await _readService.GetAllAsync(filter, transaction, cancellationToken);
 
         if (previous?.IsEmpty() ?? true)
         {

--- a/Firebend.AutoCrud.EntityFramework/EntityFrameworkEntityBuilder.cs
+++ b/Firebend.AutoCrud.EntityFramework/EntityFrameworkEntityBuilder.cs
@@ -21,13 +21,16 @@ public class EntityFrameworkEntityBuilder<TKey, TEntity> : EntityCrudBuilder<TKe
 {
     public Type DbContextType { get; }
     public Action<IServiceProvider, DbContextOptionsBuilder> DbContextOptionsBuilder { get; }
+    public bool UsePooled { get; }
 
     public EntityFrameworkEntityBuilder(IServiceCollection services,
         Type dbContextType,
-        Action<IServiceProvider, DbContextOptionsBuilder> dbContextOptionsBuilder) : base(services)
+        Action<IServiceProvider, DbContextOptionsBuilder> dbContextOptionsBuilder,
+        bool usePooled) : base(services)
     {
         DbContextType = dbContextType;
         DbContextOptionsBuilder = dbContextOptionsBuilder;
+        UsePooled = usePooled;
 
         CreateType = typeof(EntityFrameworkEntityCreateService<TKey, TEntity>);
         ReadType = typeof(EntityFrameworkEntityReadService<TKey, TEntity>);

--- a/Firebend.AutoCrud.EntityFramework/EntityFrameworkEntityCrudGenerator.cs
+++ b/Firebend.AutoCrud.EntityFramework/EntityFrameworkEntityCrudGenerator.cs
@@ -12,15 +12,18 @@ public class EntityFrameworkEntityCrudGenerator : EntityCrudGenerator
     public Action<IServiceProvider, DbContextOptionsBuilder> DbContextOptionsBuilder { get; }
 
     public Type DbContextType { get; }
+    public bool UsePooled { get; }
 
     public EntityFrameworkEntityCrudGenerator(IDynamicClassGenerator classGenerator,
         IServiceCollection services,
         Action<IServiceProvider, DbContextOptionsBuilder> dbContextOptionsBuilder,
-        Type dbContextType) : base(classGenerator,
+        Type dbContextType,
+        bool usePooled) : base(classGenerator,
         services)
     {
         DbContextOptionsBuilder = dbContextOptionsBuilder;
         DbContextType = dbContextType;
+        UsePooled = usePooled;
     }
 
     public EntityFrameworkEntityCrudGenerator AddEntity<TKey, TEntity>(
@@ -28,7 +31,7 @@ public class EntityFrameworkEntityCrudGenerator : EntityCrudGenerator
         where TKey : struct
         where TEntity : class, IEntity<TKey>, new()
     {
-        var builder = new EntityFrameworkEntityBuilder<TKey, TEntity>(Services, DbContextType, DbContextOptionsBuilder);
+        var builder = new EntityFrameworkEntityBuilder<TKey, TEntity>(Services, DbContextType, DbContextOptionsBuilder, UsePooled);
         configure(builder);
         Builders.Add(builder);
         return this;

--- a/Firebend.AutoCrud.EntityFramework/EntityFrameworkEntityCrudGeneratorExtensions.cs
+++ b/Firebend.AutoCrud.EntityFramework/EntityFrameworkEntityCrudGeneratorExtensions.cs
@@ -12,7 +12,7 @@ public static class EntityFrameworkEntityCrudGeneratorExtensions
         this IServiceCollection serviceCollection,
         Action<IServiceProvider, DbContextOptionsBuilder> dbContextOptionsBuilder,
         Action<EntityFrameworkEntityCrudGenerator> configure,
-        bool usePooled = true)
+        bool usePooled = false)
         where TContext : DbContext
     {
         if (usePooled)
@@ -30,7 +30,8 @@ public static class EntityFrameworkEntityCrudGeneratorExtensions
             new DynamicClassGenerator(),
             serviceCollection,
             dbContextOptionsBuilder,
-            typeof(TContext));
+            typeof(TContext),
+            usePooled);
 
         configure(ef);
 

--- a/Firebend.AutoCrud.EntityFramework/Firebend.AutoCrud.EntityFramework.csproj
+++ b/Firebend.AutoCrud.EntityFramework/Firebend.AutoCrud.EntityFramework.csproj
@@ -23,9 +23,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.6" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.7" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     </ItemGroup>
 

--- a/Firebend.AutoCrud.EntityFramework/Implementations/EntityFrameworkEntityTransactionFactory.cs
+++ b/Firebend.AutoCrud.EntityFramework/Implementations/EntityFrameworkEntityTransactionFactory.cs
@@ -36,6 +36,7 @@ public class EntityFrameworkEntityTransactionFactory<TKey, TEntity> : BaseDispos
     public async Task<IEntityTransaction> StartTransactionAsync(CancellationToken cancellationToken)
     {
         var context = await _dbContextProvider.GetDbContextAsync(cancellationToken);
+        context.UseUserDefinedTransaction = true;
         var transaction = await context.Database.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
         return new EntityFrameworkEntityTransaction(transaction, _outbox);
     }

--- a/Firebend.AutoCrud.EntityFramework/Interfaces/IDbContext.cs
+++ b/Firebend.AutoCrud.EntityFramework/Interfaces/IDbContext.cs
@@ -22,4 +22,8 @@ public interface IDbContext : IDisposable, IAsyncDisposable
     DatabaseFacade Database { get; }
 
     IModel Model { get; }
+
+    DbContextOptions Options { get; }
+
+    bool UseUserDefinedTransaction { get; set; }
 }

--- a/Firebend.AutoCrud.IntegrationTests/Firebend.AutoCrud.IntegrationTests.csproj
+++ b/Firebend.AutoCrud.IntegrationTests/Firebend.AutoCrud.IntegrationTests.csproj
@@ -16,7 +16,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
         <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />

--- a/Firebend.AutoCrud.Mongo.Sample/SampleHostedService.cs
+++ b/Firebend.AutoCrud.Mongo.Sample/SampleHostedService.cs
@@ -93,7 +93,9 @@ public class SampleHostedService : BackgroundService
     private void LogObject(string message, object entity = null)
     {
         // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
+#pragma warning disable CA2254
         _logger.LogInformation(message);
+#pragma warning restore CA2254
 
         if (entity != null)
         {

--- a/Firebend.AutoCrud.Mongo.Sample/SampleHostedService.cs
+++ b/Firebend.AutoCrud.Mongo.Sample/SampleHostedService.cs
@@ -25,11 +25,10 @@ public class SampleHostedService : BackgroundService
     {
         _logger = logger;
 
-        using var scope = serviceProvider.CreateScope();
-        _createService = scope.ServiceProvider.GetService<IEntityCreateService<Guid, Person>>();
-        _updateService = scope.ServiceProvider.GetService<IEntityUpdateService<Guid, Person>>();
-        _readService = scope.ServiceProvider.GetService<IPersonReadRepository>();
-        _searchService = scope.ServiceProvider.GetService<IEntitySearchService<Guid, Person, EntitySearchRequest>>();
+        _createService = serviceProvider.GetService<IEntityCreateService<Guid, Person>>();
+        _updateService = serviceProvider.GetService<IEntityUpdateService<Guid, Person>>();
+        _readService = serviceProvider.GetService<IPersonReadRepository>();
+        _searchService = serviceProvider.GetService<IEntitySearchService<Guid, Person, EntitySearchRequest>>();
 
         if (_createService == null)
         {

--- a/Firebend.AutoCrud.Mongo/Client/ErrorCodes.cs
+++ b/Firebend.AutoCrud.Mongo/Client/ErrorCodes.cs
@@ -1,0 +1,139 @@
+using System.Linq;
+
+namespace Firebend.AutoCrud.Mongo.Client;
+
+//https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.yml
+
+public static class ErrorCodes
+{
+    public const int LockTimeout = 24;
+    public const int LogWriteFailed = 42;
+    public const int NoMatchingDocument = 47;
+    public const int MaxTimeMsExpiredErrorCode = 50;
+    public const int InvalidDbRef = 55;
+    public const int ShardKeyNotFound = 61;
+    public const int WriteConcernFailed = 64;
+    public const int MultipleErrorsOccurred = 65;
+    public const int InvalidNamespace = 73;
+    public const int NetworkTimeout = 89;
+    public const int ShutdownInProgress = 91;
+    public const int DbPathInUse = 98;
+    public const int DistributedClockSkewed = 106;
+    public const int LockFailed = 107;
+    public const int WriteConflict = 112;
+    public const int ConflictingOperationInProgress = 117;
+    public const int CommandFailed = 125;
+    public const int LockNotFound = 128;
+    public const int ReadConcernMajorityNotAvailableYet = 134;
+    public const int RemoteOplogStale = 138;
+    public const int OplogOutOfOrder = 152;
+    public const int DurationOverflow = 159;
+    public const int TransportSessionClosed = 172;
+    public const int TransportSessionNotFound = 173;
+    public const int TransportSessionUnknown = 174;
+    public const int MasterSlaveConnectionFailure = 190;
+    public const int ChunkRangeCleanupPending = 200;
+    public const int TimeProofMismatch = 204;
+    public const int NoSuchSession = 206;
+    public const int TooManyLocks = 208;
+    public const int DuplicateSession = 213;
+    public const int IncompleteTransactionHistory = 217;
+    public const int SessionTransferIncomplete = 228;
+    public const int InternalErrorNotSupported = 235;
+    public const int CursorKilled = 237;
+    public const int NoSuchTransaction = 251;
+    public const int TransactionCommitted = 256;
+    public const int TransactionTooLarge = 257;
+    public const int TooManyLogicalSessions = 261;
+    public const int ExceededTimeLimit = 262;
+    public const int TooManyFilesOpen = 264;
+    public const int ClientDisconnect = 279;
+    public const int TransactionCoordinatorSteppingDown = 281;
+    public const int TransactionCoordinatorReachedAbortDecision = 282;
+    public const int TransactionExceededLifetimeLimitSeconds = 290;
+    public const int QueryExceededMemoryLimitNoDiskUseAllowed = 292;
+    public const int ObjectIsBusy = 314;
+    public const int SkipCommandExecution = 330;
+    public const int InterruptedDueToStorageChange = 355;
+    public const int InternalTransactionNotSupported = 358;
+    public const int TemporarilyUnavailable = 365;
+    public const int DuplicateKeyId = 386;
+    public const int StreamTerminated = 398;
+    public const int StreamProcessorWorkerOutOfMemory = 418;
+    public const int StreamProcessorAtlasConnectionError = 421;
+    public const int SocketException = 9001;
+    public const int DuplicateKey = 11000;
+    public const int InterruptedDueToReplStateChange = 11602;
+    public const int ClientMarkedKilled = 46841;
+    public const int BackupCursorOpenConflictWithCheckpoint = 50915;
+    public const int RetriableRemoteCommandFailure = 91331;
+
+    public static readonly int[] All =
+    [
+        LockTimeout,
+        LogWriteFailed,
+        NoMatchingDocument,
+        MaxTimeMsExpiredErrorCode,
+        InvalidDbRef,
+        ShardKeyNotFound,
+        WriteConcernFailed,
+        MultipleErrorsOccurred,
+        InvalidNamespace,
+        NetworkTimeout,
+        ShutdownInProgress,
+        DbPathInUse,
+        DistributedClockSkewed,
+        LockFailed,
+        WriteConflict,
+        ConflictingOperationInProgress,
+        CommandFailed,
+        LockNotFound,
+        ReadConcernMajorityNotAvailableYet,
+        RemoteOplogStale,
+        OplogOutOfOrder,
+        DurationOverflow,
+        TransportSessionClosed,
+        TransportSessionNotFound,
+        TransportSessionUnknown,
+        MasterSlaveConnectionFailure,
+        ChunkRangeCleanupPending,
+        TimeProofMismatch,
+        NoSuchSession,
+        TooManyLocks,
+        DuplicateSession,
+        IncompleteTransactionHistory,
+        SessionTransferIncomplete,
+        InternalErrorNotSupported,
+        CursorKilled,
+        NoSuchTransaction,
+        TransactionCommitted,
+        TransactionTooLarge,
+        TooManyLogicalSessions,
+        ExceededTimeLimit,
+        TooManyFilesOpen,
+        ClientDisconnect,
+        TransactionCoordinatorSteppingDown,
+        TransactionCoordinatorReachedAbortDecision,
+        TransactionExceededLifetimeLimitSeconds,
+        QueryExceededMemoryLimitNoDiskUseAllowed,
+        ObjectIsBusy,
+        SkipCommandExecution,
+        InterruptedDueToStorageChange,
+        InternalTransactionNotSupported,
+        TemporarilyUnavailable,
+        DuplicateKeyId,
+        StreamTerminated,
+        StreamProcessorWorkerOutOfMemory,
+        StreamProcessorAtlasConnectionError,
+        SocketException,
+        DuplicateKey,
+        InterruptedDueToReplStateChange,
+        ClientMarkedKilled,
+        BackupCursorOpenConflictWithCheckpoint,
+        RetriableRemoteCommandFailure
+    ];
+
+    public static readonly int[] DuplicateKeys = [DuplicateKey, DuplicateKeyId];
+
+    public static readonly int[] Retryable = All.Except(DuplicateKeys).ToArray();
+}

--- a/Firebend.AutoCrud.Mongo/Client/Labels.cs
+++ b/Firebend.AutoCrud.Mongo/Client/Labels.cs
@@ -1,7 +1,16 @@
 namespace Firebend.AutoCrud.Mongo.Client;
 
+//https://github.com/mongodb/mongo/blob/f7ffb413e2e47d793f6fbdc3220b12a0b15ea7e7/src/mongo/db/error_labels.h#L47
+//https://github.com/mongodb/mongo/blob/master/src/mongo/db/error_labels.h
 public static class Labels
 {
-    public const string TransientTransactionErrorLabel = "TransientTransactionError";
     public const string UnknownTransactionCommitResultLabel = "UnknownTransactionCommitResult";
+
+    public const string TransientTransaction = "TransientTransactionError";
+    public const string RetryableWrite = "RetryableWriteError";
+    public const string NonResumableChangeStream = "NonResumableChangeStreamError";
+    public const string ResumableChangeStream = "ResumableChangeStreamError";
+    public const string NoWritesPerformed = "NoWritesPerformed";
+    public const string StreamProcessorRetryableError = "StreamProcessorRetryableError";
+    public const string StreamProcessorUserError = "StreamProcessorUserError";
 }

--- a/Firebend.AutoCrud.Mongo/Client/Labels.cs
+++ b/Firebend.AutoCrud.Mongo/Client/Labels.cs
@@ -1,0 +1,7 @@
+namespace Firebend.AutoCrud.Mongo.Client;
+
+public static class Labels
+{
+    public const string TransientTransactionErrorLabel = "TransientTransactionError";
+    public const string UnknownTransactionCommitResultLabel = "UnknownTransactionCommitResult";
+}

--- a/Firebend.AutoCrud.Mongo/Client/MongoRetryService.cs
+++ b/Firebend.AutoCrud.Mongo/Client/MongoRetryService.cs
@@ -28,7 +28,7 @@ public class MongoRetryService : IMongoRetryService
                     throw;
                 }
 
-                if(maxTries > 0 && tries >= maxTries)
+                if (maxTries > 0 && tries >= maxTries)
                 {
                     throw;
                 }

--- a/Firebend.AutoCrud.Mongo/Client/MongoRetryService.cs
+++ b/Firebend.AutoCrud.Mongo/Client/MongoRetryService.cs
@@ -1,20 +1,16 @@
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 using Firebend.AutoCrud.Mongo.Interfaces;
-using MongoDB.Driver;
 
 namespace Firebend.AutoCrud.Mongo.Client;
 
 public class MongoRetryService : IMongoRetryService
 {
-    private static readonly TimeSpan TransactionTimeout = TimeSpan.FromSeconds(120);
-
     public async Task<TReturn> RetryErrorAsync<TReturn>(Func<Task<TReturn>> method, int maxTries)
     {
         var tries = 0;
-        double delay = 200;
+        var delay = 200;
         var now = Stopwatch.GetTimestamp();
 
         while (true)
@@ -27,55 +23,20 @@ public class MongoRetryService : IMongoRetryService
             {
                 tries++;
 
-                if (!ShouldRetry(ex, now) || tries >= maxTries)
+                if (MongoRetryUtilities.ShouldRetry(ex, now) is false)
+                {
+                    throw;
+                }
+
+                if(maxTries > 0 && tries >= maxTries)
                 {
                     throw;
                 }
 
                 delay *= 2;
 
-                await Task.Delay(TimeSpan.FromMilliseconds(delay));
+                await Task.Delay(delay);
             }
         }
-    }
-
-    public static bool ShouldRetry(Exception exception, long now) =>
-        exception switch
-        {
-            not null when exception.Message.Contains("duplicate key") => false,
-            MongoWriteConcernException e => HasWriteConcern(e),
-            MongoCommandException e => HasAnyErrorCode(e, ErrorCodes.Retryable),
-            MongoBulkWriteException => false,
-            MongoExecutionTimeoutException { Code: ErrorCodes.MaxTimeMsExpiredErrorCode } => true,
-            MongoException e when HasAnyLabel(e,
-                Labels.TransientTransaction,
-                Labels.UnknownTransactionCommitResultLabel) => true,
-            _ => HasTimedOut(now)
-        };
-
-    public static bool HasAnyErrorCode(MongoCommandException mongoException, params int[] codes)
-        => codes.Contains(mongoException.Code);
-
-    public static bool HasAnyLabel(MongoException mongoException, params string[] labels)
-        => labels.Any(mongoException.HasErrorLabel);
-
-    public static bool HasWriteConcern(MongoWriteConcernException writeConcernException)
-    {
-        var writeConcernError = writeConcernException
-            .WriteConcernResult
-            .Response?
-            .GetValue("writeConcernError", null)
-            ?.AsBsonDocument;
-
-        var code = writeConcernError?.GetValue("code", -1).ToInt32() ?? 0;
-
-        return code != 0 && ErrorCodes.Retryable.Contains(code);
-    }
-
-    private static bool HasTimedOut(long startTime, TimeSpan? timeout = null)
-    {
-        timeout ??= TransactionTimeout;
-        var hasTimedOut = Stopwatch.GetElapsedTime(startTime) >= timeout;
-        return hasTimedOut;
     }
 }

--- a/Firebend.AutoCrud.Mongo/Client/MongoRetryService.cs
+++ b/Firebend.AutoCrud.Mongo/Client/MongoRetryService.cs
@@ -48,18 +48,18 @@ public class MongoRetryService : IMongoRetryService
             MongoBulkWriteException => false,
             MongoExecutionTimeoutException { Code: ErrorCodes.MaxTimeMsExpiredErrorCode } => true,
             MongoException e when HasAnyLabel(e,
-                Labels.TransientTransactionErrorLabel,
+                Labels.TransientTransaction,
                 Labels.UnknownTransactionCommitResultLabel) => true,
             _ => HasTimedOut(now)
         };
 
-    private static bool HasAnyErrorCode(MongoCommandException mongoException, params int[] codes)
+    public static bool HasAnyErrorCode(MongoCommandException mongoException, params int[] codes)
         => codes.Contains(mongoException.Code);
 
-    private static bool HasAnyLabel(MongoException mongoException, params string[] labels)
+    public static bool HasAnyLabel(MongoException mongoException, params string[] labels)
         => labels.Any(mongoException.HasErrorLabel);
 
-    private static bool HasWriteConcern(MongoWriteConcernException writeConcernException)
+    public static bool HasWriteConcern(MongoWriteConcernException writeConcernException)
     {
         var writeConcernError = writeConcernException
             .WriteConcernResult

--- a/Firebend.AutoCrud.Mongo/Client/MongoRetryUtilities.cs
+++ b/Firebend.AutoCrud.Mongo/Client/MongoRetryUtilities.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using MongoDB.Driver;
+// ReSharper disable MemberCanBePrivate.Global
+
+namespace Firebend.AutoCrud.Mongo.Client;
+
+public static class MongoRetryUtilities
+{
+    private static readonly TimeSpan TransactionTimeout = TimeSpan.FromSeconds(120);
+
+    public static bool ShouldRetry(Exception exception, long now) =>
+        exception switch
+        {
+            not null when exception.Message.Contains("duplicate key") => false,
+            MongoWriteConcernException e => e.HasWriteConcern(),
+            MongoCommandException e => e.HasAnyErrorCode(ErrorCodes.Retryable),
+            MongoBulkWriteException => false,
+            MongoExecutionTimeoutException { Code: ErrorCodes.MaxTimeMsExpiredErrorCode } => true,
+            MongoException e when e.HasAnyLabel(Labels.TransientTransaction, Labels.UnknownTransactionCommitResultLabel) => true,
+            _ => HasTimedOut(now)
+        };
+
+    public static bool HasAnyErrorCode(this MongoCommandException mongoException, params int[] codes)
+        => codes.Contains(mongoException.Code);
+
+    public static bool HasAnyLabel(this MongoException mongoException, params string[] labels)
+        => labels.Any(mongoException.HasErrorLabel);
+
+    public static bool HasWriteConcern(this MongoWriteConcernException writeConcernException)
+    {
+        var writeConcernError = writeConcernException
+            .WriteConcernResult
+            .Response?
+            .GetValue("writeConcernError", null)
+            ?.AsBsonDocument;
+
+        var code = writeConcernError?.GetValue("code", -1).ToInt32() ?? 0;
+
+        return code != 0 && ErrorCodes.Retryable.Contains(code);
+    }
+
+    public static bool HasTimedOut(long startTime, TimeSpan? timeout = null)
+    {
+        timeout ??= TransactionTimeout;
+        var hasTimedOut = Stopwatch.GetElapsedTime(startTime) >= timeout;
+        return hasTimedOut;
+    }
+}

--- a/Firebend.AutoCrud.Mongo/HostedServices/ConfigureCollectionsHostedService.cs
+++ b/Firebend.AutoCrud.Mongo/HostedServices/ConfigureCollectionsHostedService.cs
@@ -23,9 +23,7 @@ public class ConfigureCollectionsHostedService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        using var scope = _serviceProvider.CreateScope();
-
-        var collections = scope.ServiceProvider.GetService<IEnumerable<IConfigureCollection>>();
+        var collections = _serviceProvider.GetService<IEnumerable<IConfigureCollection>>();
 
         if (collections != null)
         {

--- a/Firebend.AutoCrud.Mongo/HostedServices/MongoMigrationHostedService.cs
+++ b/Firebend.AutoCrud.Mongo/HostedServices/MongoMigrationHostedService.cs
@@ -15,20 +15,19 @@ namespace Firebend.AutoCrud.Mongo.HostedServices;
 
 public class MongoMigrationHostedService : BackgroundService
 {
-    private readonly IEnumerable<IMongoMigration> _migrations;
     private readonly IMongoDefaultDatabaseSelector _databaseSelector;
-    private readonly IMongoMigrationConnectionStringProvider _mongoMigrationConnectionStringProvider;
     private readonly ILogger _logger;
+    private readonly IEnumerable<IMongoMigration> _migrations;
+    private readonly IMongoMigrationConnectionStringProvider _mongoMigrationConnectionStringProvider;
 
-    public MongoMigrationHostedService(ILogger<MongoMigrationHostedService> logger, IServiceProvider serviceProvider, IMongoMigrationConnectionStringProvider mongoMigrationConnectionStringProvider)
+    public MongoMigrationHostedService(ILogger<MongoMigrationHostedService> logger, IServiceProvider serviceProvider,
+        IMongoMigrationConnectionStringProvider mongoMigrationConnectionStringProvider)
     {
         _mongoMigrationConnectionStringProvider = mongoMigrationConnectionStringProvider;
         _logger = logger;
 
-        using var scope = serviceProvider.CreateScope();
-
-        _migrations = scope.ServiceProvider.GetService<IEnumerable<IMongoMigration>>();
-        _databaseSelector = scope.ServiceProvider.GetService<IMongoDefaultDatabaseSelector>();
+        _migrations = serviceProvider.GetService<IEnumerable<IMongoMigration>>();
+        _databaseSelector = serviceProvider.GetService<IMongoDefaultDatabaseSelector>();
     }
 
     protected override Task ExecuteAsync(CancellationToken stoppingToken) => DoMigration(stoppingToken);
@@ -63,8 +62,8 @@ public class MongoMigrationHostedService : BackgroundService
             .FirstOrDefaultAsync(cancellationToken);
 
         foreach (var migration in _migrations
-            .Where(x => x.Version.Version > maxVersion)
-            .OrderBy(x => x.Version.Version))
+                     .Where(x => x.Version.Version > maxVersion)
+                     .OrderBy(x => x.Version.Version))
         {
             try
             {

--- a/Firebend.AutoCrud.Mongo/MongoDbEntityBuilder.cs
+++ b/Firebend.AutoCrud.Mongo/MongoDbEntityBuilder.cs
@@ -122,7 +122,7 @@ public class MongoDbEntityBuilder<TKey, TEntity> : EntityCrudBuilder<TKey, TEnti
 
         WithRegistration<IEntityTransactionFactory<TKey, TEntity>, MongoEntityTransactionFactory<TKey, TEntity>>(false);
 
-        WithRegistration<IMongoRetryService, MongoRetryService>(false);
+        WithRegistration<IMongoRetryService, MongoRetryService>(false, false, ServiceLifetime.Singleton);
     }
 
     private void RegisterEntityConfiguration()

--- a/Firebend.AutoCrud.Tests/Core/Services/ClientRequestTransactionManagerTests.cs
+++ b/Firebend.AutoCrud.Tests/Core/Services/ClientRequestTransactionManagerTests.cs
@@ -53,10 +53,6 @@ public class ClientRequestTransactionManagerTests
         var serviceScope = _fixture.Freeze<Mock<IServiceScope>>();
         serviceScope.Setup(x => x.ServiceProvider)
             .Returns(_serviceProvider.Object);
-
-        var serviceFactoryScope = _fixture.Freeze<Mock<IServiceScopeFactory>>();
-        serviceFactoryScope.Setup(x => x.CreateScope())
-            .Returns(serviceScope.Object);
     }
 
     private Mock<TestTransaction> CreateMockTransaction()

--- a/Firebend.AutoCrud.Tests/Firebend.AutoCrud.Tests.csproj
+++ b/Firebend.AutoCrud.Tests/Firebend.AutoCrud.Tests.csproj
@@ -16,7 +16,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
         <PackageReference Include="Microsoft.OpenApi" Version="1.6.15" />
         <PackageReference Include="nunit" Version="4.1.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/Firebend.AutoCrud.Tests/Web/Implementations/Authorization/EntityAuthProviderTests.cs
+++ b/Firebend.AutoCrud.Tests/Web/Implementations/Authorization/EntityAuthProviderTests.cs
@@ -21,7 +21,6 @@ namespace Firebend.AutoCrud.Tests.Web.Implementations.Authorization;
 public class EntityAuthProviderTests
 {
     private Fixture _fixture;
-    private Mock<IServiceScopeFactory> _serviceScopeFactory;
     private Mock<IServiceScope> _serviceScope;
     private Mock<IServiceProvider> _serviceProvider;
     private Mock<IEntityReadService<Guid, ActionFilterTestHelper.TestEntity>> _entityReadService;
@@ -34,7 +33,6 @@ public class EntityAuthProviderTests
         _fixture = new Fixture();
         _fixture.Customize(new AutoMoqCustomization());
         _authService = new Mock<IAuthorizationService>();
-        _serviceScopeFactory = new Mock<IServiceScopeFactory>();
         _serviceScope = new Mock<IServiceScope>();
         _serviceProvider = new Mock<IServiceProvider>();
         _entityReadService = new Mock<IEntityReadService<Guid, ActionFilterTestHelper.TestEntity>>();
@@ -44,7 +42,6 @@ public class EntityAuthProviderTests
             .Returns(_entityReadService.Object);
 
         _serviceScope.Setup(x => x.ServiceProvider).Returns(_serviceProvider.Object);
-        _serviceScopeFactory.Setup(x => x.CreateScope()).Returns(_serviceScope.Object);
 
         _entityKeyParser = new Mock<IEntityKeyParser<Guid, ActionFilterTestHelper.TestEntity, V1>>();
         _entityKeyParser.Setup(s => s.ParseKey(
@@ -64,7 +61,7 @@ public class EntityAuthProviderTests
 
         // when
         var entityAuthProvider =
-            new DefaultEntityAuthProvider(_authService.Object, _serviceScopeFactory.Object);
+            new DefaultEntityAuthProvider(_authService.Object, _serviceProvider.Object);
 
         // then
         Assert.ThrowsAsync<DependencyResolverException>(() =>
@@ -83,7 +80,7 @@ public class EntityAuthProviderTests
 
         // when
         var entityAuthProvider =
-            new DefaultEntityAuthProvider(_authService.Object, _serviceScopeFactory.Object);
+            new DefaultEntityAuthProvider(_authService.Object, _serviceProvider.Object);
 
         // then
         Assert.ThrowsAsync<DependencyResolverException>(() =>
@@ -102,7 +99,7 @@ public class EntityAuthProviderTests
 
         // when
         var entityAuthProvider =
-            new DefaultEntityAuthProvider(_authService.Object, _serviceScopeFactory.Object);
+            new DefaultEntityAuthProvider(_authService.Object, _serviceProvider.Object);
 
         // then
         Assert.ThrowsAsync<ArgumentException>(() =>
@@ -119,7 +116,7 @@ public class EntityAuthProviderTests
 
         // when
         var entityAuthProvider =
-            new DefaultEntityAuthProvider(_authService.Object, _serviceScopeFactory.Object);
+            new DefaultEntityAuthProvider(_authService.Object, _serviceProvider.Object);
 
         // then
         await entityAuthProvider.AuthorizeEntityAsync<Guid, ActionFilterTestHelper.TestEntity, V1>(
@@ -138,7 +135,7 @@ public class EntityAuthProviderTests
 
         // when
         var entityAuthProvider =
-            new DefaultEntityAuthProvider(_authService.Object, _serviceScopeFactory.Object);
+            new DefaultEntityAuthProvider(_authService.Object, _serviceProvider.Object);
 
         // then
         await entityAuthProvider.AuthorizeEntityAsync<Guid, ActionFilterTestHelper.TestEntity, V1>(

--- a/Firebend.AutoCrud.Web.Sample/DbContexts/PersonDbContext.cs
+++ b/Firebend.AutoCrud.Web.Sample/DbContexts/PersonDbContext.cs
@@ -1,8 +1,8 @@
 using Firebend.AutoCrud.CustomFields.EntityFramework;
+using Firebend.AutoCrud.EntityFramework.Abstractions;
 using Firebend.AutoCrud.EntityFramework.Comparers;
 using Firebend.AutoCrud.EntityFramework.Converters;
 using Firebend.AutoCrud.EntityFramework.CustomCommands;
-using Firebend.AutoCrud.EntityFramework.Interfaces;
 using Firebend.AutoCrud.Web.Sample.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 
 namespace Firebend.AutoCrud.Web.Sample.DbContexts;
 
-public class PersonDbContext : DbContext, IDbContext
+public class PersonDbContext : AbstractDbContext
 {
     public PersonDbContext(DbContextOptions options) : base(options)
     {

--- a/Firebend.AutoCrud.Web.Sample/Firebend.AutoCrud.Web.Sample.csproj
+++ b/Firebend.AutoCrud.Web.Sample/Firebend.AutoCrud.Web.Sample.csproj
@@ -27,14 +27,14 @@
     <PackageReference Include="MassTransit" Version="8.2.3" />
     <PackageReference Include="MassTransit.Newtonsoft" Version="8.2.3" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.7" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.6.2" />
   </ItemGroup>

--- a/Firebend.AutoCrud.Web.Sample/Startup.cs
+++ b/Firebend.AutoCrud.Web.Sample/Startup.cs
@@ -8,6 +8,7 @@ using Firebend.AutoCrud.Core.Interfaces.Services.Entities;
 using Firebend.AutoCrud.CustomFields.Web;
 using Firebend.AutoCrud.EntityFramework;
 using Firebend.AutoCrud.EntityFramework.CustomCommands;
+using Firebend.AutoCrud.EntityFramework.Elastic;
 using Firebend.AutoCrud.Mongo;
 using Firebend.AutoCrud.Web.Sample.Authorization;
 using Firebend.AutoCrud.Web.Sample.DbContexts;
@@ -85,10 +86,7 @@ public static class Startup
                 .WithDomainEventContextProvider<SampleDomainEventContextProvider>()
             )
             .UsingEfCrud<PersonDbContext>(
-                (_, opt) => opt
-                    .UseSqlServer(configuration.GetConnectionString("SqlServer"))
-                    .AddFirebendFunctions()
-                    .EnableSensitiveDataLogging(),
+                SqlServerBuilder.Get(o => o.EnableSensitiveDataLogging()),
                 ef =>
                 {
                     ef.AddEfPerson(configuration)

--- a/Firebend.AutoCrud.Web.Sample/Startup.cs
+++ b/Firebend.AutoCrud.Web.Sample/Startup.cs
@@ -86,7 +86,7 @@ public static class Startup
                 .WithDomainEventContextProvider<SampleDomainEventContextProvider>()
             )
             .UsingEfCrud<PersonDbContext>(
-                SqlServerBuilder.Get(o => o.EnableSensitiveDataLogging()),
+                AutoCrudSqlServerOptionsBuilder.Build(o => o.EnableSensitiveDataLogging()),
                 ef =>
                 {
                     ef.AddEfPerson(configuration)

--- a/Firebend.AutoCrud.Web/Firebend.AutoCrud.Web.csproj
+++ b/Firebend.AutoCrud.Web/Firebend.AutoCrud.Web.csproj
@@ -27,7 +27,7 @@
       <PackageReference Include="Humanizer.Core" Version="2.14.1" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-      <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.6" />
+      <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.7" />
       <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
     </ItemGroup>
 

--- a/Firebend.AutoCrud.Web/Implementations/Authorization/DefaultEntityAuthProvider.cs
+++ b/Firebend.AutoCrud.Web/Implementations/Authorization/DefaultEntityAuthProvider.cs
@@ -1,12 +1,12 @@
+using System;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Firebend.AutoCrud.Web.Implementations.Authorization;
 
 public class DefaultEntityAuthProvider : EntityAuthProvider
 {
     public DefaultEntityAuthProvider(IAuthorizationService authorizationService,
-        IServiceScopeFactory serviceScopeFactory) : base(authorizationService, serviceScopeFactory)
+        IServiceProvider serviceProvider) : base(authorizationService, serviceProvider)
     {
     }
 }

--- a/Firebend.AutoCrud.Web/Implementations/Authorization/EntityAuthProvider.cs
+++ b/Firebend.AutoCrud.Web/Implementations/Authorization/EntityAuthProvider.cs
@@ -16,12 +16,12 @@ namespace Firebend.AutoCrud.Web.Implementations.Authorization;
 public abstract class EntityAuthProvider : IEntityAuthProvider
 {
     private readonly IAuthorizationService _authorizationService;
-    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly IServiceProvider _serviceProvider;
 
-    protected EntityAuthProvider(IAuthorizationService authorizationService, IServiceScopeFactory serviceScopeFactory)
+    protected EntityAuthProvider(IAuthorizationService authorizationService, IServiceProvider serviceProvider)
     {
         _authorizationService = authorizationService;
-        _serviceScopeFactory = serviceScopeFactory;
+        _serviceProvider = serviceProvider;
     }
 
     private TKey GetEntityKeyAsync<TKey, TEntity, TVersion>(string entityIdString)
@@ -29,8 +29,7 @@ public abstract class EntityAuthProvider : IEntityAuthProvider
         where TEntity : class, IEntity<TKey>
         where TVersion : class, IAutoCrudApiVersion
     {
-        using var scope = _serviceScopeFactory.CreateScope();
-        var keyParser = scope.ServiceProvider.GetService<IEntityKeyParser<TKey, TEntity, TVersion>>() ?? throw new DependencyResolverException($"Cannot resolve key parser for {nameof(TEntity)}");
+        var keyParser = _serviceProvider.GetService<IEntityKeyParser<TKey, TEntity, TVersion>>() ?? throw new DependencyResolverException($"Cannot resolve key parser for {nameof(TEntity)}");
 
         var entityId = keyParser.ParseKey(entityIdString) ?? throw new ArgumentException($"Failed to parse id for {nameof(TEntity)}");
 
@@ -41,8 +40,7 @@ public abstract class EntityAuthProvider : IEntityAuthProvider
         where TKey : struct
         where TEntity : class, IEntity<TKey>
     {
-        using var scope = _serviceScopeFactory.CreateScope();
-        var readService = scope.ServiceProvider.GetService<IEntityReadService<TKey, TEntity>>() ?? throw new DependencyResolverException($"Cannot resolve read service for {nameof(TEntity)}");
+        var readService = _serviceProvider.GetService<IEntityReadService<TKey, TEntity>>() ?? throw new DependencyResolverException($"Cannot resolve read service for {nameof(TEntity)}");
 
         using (readService)
         {


### PR DESCRIPTION
- Adds mongo error codes and labels as constants
- Leverages those constants in retry
- Provides a default db context options builder that includes sql azure retry logic and auto crud functions added
- Passes entity transaction to methods where it should have been passed 
- Fixes the entity framework create client not handling db exceptions by creating a base class that update and create clients inherit 
- Shy away from scoped service provider in favor of IServiceProvider
- Provide callbacks and access to entity outbox enrollments
- Adds a custom execution strategy that will leverage the existing sql server retry execution strategy but allow for it to be overwritten when using user defined transactions


![image](https://github.com/user-attachments/assets/09744900-c365-4a16-8976-97f0c7245ca5)
